### PR TITLE
refactor: correct endpoint path confusion & conflict

### DIFF
--- a/src/hooks/useShmupArticle.ts
+++ b/src/hooks/useShmupArticle.ts
@@ -5,13 +5,13 @@ import { useShmupRecordStore } from '^/stores/shmup-record';
 import { ShmupRecord } from '^/types';
 import { getAPIURL } from '^/utils/api-url';
 
-export function useShmupArticle(pathName: string, currentRecordId?: string) {
+export function useShmupArticle(
+  endpointName: string,
+  currentRecordId?: string
+) {
   const recordArticle = useShmupRecordStore((state) => state.recordArticle);
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [isError, setIsError] = useState<boolean>(false);
-
-  const pathNameSplit = pathName.split('/').filter((path) => path.length > 1);
-  const endpointName = pathNameSplit[pathNameSplit.length - 1];
 
   useEffect(() => {
     useShmupRecordStore.getState().setRecordArticle(undefined);

--- a/src/hooks/useShmupArticle.ts
+++ b/src/hooks/useShmupArticle.ts
@@ -11,6 +11,7 @@ export function useShmupArticle(pathName: string, currentRecordId?: string) {
   const [isError, setIsError] = useState<boolean>(false);
 
   const pathNameSplit = pathName.split('/').filter((path) => path.length > 1);
+  const endpointName = pathNameSplit[pathNameSplit.length - 1];
 
   useEffect(() => {
     useShmupRecordStore.getState().setRecordArticle(undefined);
@@ -22,7 +23,7 @@ export function useShmupArticle(pathName: string, currentRecordId?: string) {
       setIsLoading(true);
       try {
         const response = await axios.get<ShmupRecord>(
-          getAPIURL(...pathNameSplit, currentRecordId)
+          getAPIURL('records', endpointName, currentRecordId)
         );
         useShmupRecordStore.getState().setRecordArticle({
           ...response.data,
@@ -36,7 +37,7 @@ export function useShmupArticle(pathName: string, currentRecordId?: string) {
       }
       setIsLoading(false);
     })();
-  }, [currentRecordId]);
+  }, [endpointName, currentRecordId]);
 
   return {
     recordArticle,

--- a/src/hooks/useShmupRecordIds.ts
+++ b/src/hooks/useShmupRecordIds.ts
@@ -10,6 +10,7 @@ export function useShmupRecordIds(pathName: string) {
   const [isError, setIsError] = useState<boolean>(false);
 
   const pathNameSplit = pathName.split('/').filter((path) => path.length > 1);
+  const endpointName = pathNameSplit[pathNameSplit.length - 1];
 
   useEffect(() => {
     (async () => {
@@ -18,7 +19,7 @@ export function useShmupRecordIds(pathName: string) {
       setIsLoading(true);
       try {
         const response = await axios.get<string[]>(
-          getAPIURL(...pathNameSplit, 'selection')
+          getAPIURL('records', endpointName, 'selection')
         );
         useShmupRecordStore.getState().setRecordIds(response.data);
       } catch (error) {

--- a/src/hooks/useShmupRecordIds.ts
+++ b/src/hooks/useShmupRecordIds.ts
@@ -4,13 +4,10 @@ import { useEffect, useState } from 'react';
 import { useShmupRecordStore } from '^/stores/shmup-record';
 import { getAPIURL } from '^/utils/api-url';
 
-export function useShmupRecordIds(pathName: string) {
+export function useShmupRecordIds(endpointName: string) {
   const recordIds = useShmupRecordStore((state) => state.recordIds);
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [isError, setIsError] = useState<boolean>(false);
-
-  const pathNameSplit = pathName.split('/').filter((path) => path.length > 1);
-  const endpointName = pathNameSplit[pathNameSplit.length - 1];
 
   useEffect(() => {
     (async () => {
@@ -30,7 +27,7 @@ export function useShmupRecordIds(pathName: string) {
       }
       setIsLoading(false);
     })();
-  }, [pathName]);
+  }, [endpointName]);
 
   return {
     recordIds,

--- a/src/pages/RecordPage/index.tsx
+++ b/src/pages/RecordPage/index.tsx
@@ -44,11 +44,16 @@ const ArticleSkeletonArea = styled.div`
 
 export function RecordPage() {
   const location = useLocation();
+  const pathNameSplit = location.pathname
+    .split('/')
+    .filter((path) => path.length > 1);
+  const endpointName = pathNameSplit[pathNameSplit.length - 1];
+
   const {
     recordIds,
     isLoading: isRecordIdsLoading,
     isError: isRecordIdsError,
-  } = useShmupRecordIds(location.pathname);
+  } = useShmupRecordIds(endpointName);
   const currentRecordId = useShmupRecordStore((state) => state.currentRecordId);
   const setCurrentRecordId = useShmupRecordStore(
     (state) => state.setCurrentRecordId
@@ -57,7 +62,7 @@ export function RecordPage() {
     recordArticle,
     isLoading: isRecordArticleLoading,
     isError: isRecordArticleError,
-  } = useShmupArticle(location.pathname, currentRecordId);
+  } = useShmupArticle(endpointName, currentRecordId);
 
   useEffect(() => {
     useShmupRecordStore


### PR DESCRIPTION
- Corrected shmup record API endpoint path to reduce unnecessary path confusion and conflicts. (such as `dodonpachi/dodonpachi-cshot/2023-09-10` and `galagaarrangement/2023-09-10`)
- Changed 2 shmup record hooks (`useShmupArticle` and `useShmupRecordIds`) to use endpoint name instead of whole path name.