### PR TITLE
improvement: use consistent routing for shmup records

### DIFF
--- a/src/components/molecules/NavItemTree/index.test.tsx
+++ b/src/components/molecules/NavItemTree/index.test.tsx
@@ -11,9 +11,7 @@ describe('NavItemTree', () => {
   const routes = [
     {
       path: '/',
-      element: (
-        <NavItemTree depth={3} nodeInfo={navNodeInfoForTest} linkTo="/" />
-      ),
+      element: <NavItemTree depth={3} nodeInfo={navNodeInfoForTest} />,
     },
   ];
 

--- a/src/components/molecules/NavItemTree/index.tsx
+++ b/src/components/molecules/NavItemTree/index.tsx
@@ -7,18 +7,17 @@ import { NavItemButton } from '^/components/atoms/NavItemButton';
 interface Props {
   depth: number;
   nodeInfo: NavNodeInfo;
-  linkTo: string;
 }
 
-export function NavItemTree({ depth, nodeInfo, linkTo }: Props) {
+export function NavItemTree({ depth, nodeInfo }: Props) {
   const navigate = useNavigate();
 
   const isLeaf =
     nodeInfo.childNavNodes === undefined || nodeInfo.childNavNodes.length === 0;
 
   const handleOnClick = () => {
-    if (isLeaf) {
-      navigate(linkTo);
+    if (isLeaf && nodeInfo.linkTo !== undefined) {
+      navigate(nodeInfo.linkTo);
     }
   };
 
@@ -28,7 +27,6 @@ export function NavItemTree({ depth, nodeInfo, linkTo }: Props) {
           key={childNavNode.id}
           depth={depth + 1}
           nodeInfo={childNavNode}
-          linkTo={`${linkTo}/${childNavNode.id}`}
         />
       ))
     : null;

--- a/src/components/organisms/NavSidebar/index.tsx
+++ b/src/components/organisms/NavSidebar/index.tsx
@@ -20,12 +20,7 @@ interface Props {
 
 export function NavSidebar({ rootNavNodes }: Props) {
   const renderRootNavNodes = rootNavNodes.map((navNode) => (
-    <NavItemTree
-      key={navNode.id}
-      depth={0}
-      nodeInfo={navNode}
-      linkTo={`/${navNode.id}`}
-    />
+    <NavItemTree key={navNode.id} depth={0} nodeInfo={navNode} />
   ));
 
   return <Root>{renderRootNavNodes}</Root>;

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -23,9 +23,11 @@ export const navNodeInfoForTest: NavNodeInfo = {
 export const rootNavNodes: NavNodeInfo[] = [
   {
     id: 'intro',
+    linkTo: '/intro',
   },
   {
     id: 'criteria',
+    linkTo: '/criteria',
   },
   {
     id: 'records',
@@ -35,12 +37,15 @@ export const rootNavNodes: NavNodeInfo[] = [
         childNavNodes: [
           {
             id: 'dodonpachi-ashot',
+            linkTo: '/records/dodonpachi-ashot',
           },
           {
             id: 'dodonpachi-blaser',
+            linkTo: '/records/dodonpachi-blaser',
           },
           {
             id: 'dodonpachi-cshot',
+            linkTo: '/records/dodonpachi-cshot',
           },
         ],
       },

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -27,14 +27,8 @@ const router = createBrowserRouter([
         path: 'criteria',
         element: <CriteriaPage />,
       },
-      // For games with single type
       {
         path: 'records/:typeId',
-        element: <RecordPage />,
-      },
-      // For games with various types
-      {
-        path: 'records/:gameId/:typeId',
         element: <RecordPage />,
       },
     ],

--- a/src/pages/RecordPage/index.tsx
+++ b/src/pages/RecordPage/index.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react';
 import { styled } from 'styled-components';
-import { useLocation } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 
 import { Article } from '^/components/organisms/Article';
 import { RecordDropdown } from '^/components/molecules/RecordDropdown';
@@ -43,17 +43,17 @@ const ArticleSkeletonArea = styled.div`
 `;
 
 export function RecordPage() {
-  const location = useLocation();
-  const pathNameSplit = location.pathname
-    .split('/')
-    .filter((path) => path.length > 1);
-  const endpointName = pathNameSplit[pathNameSplit.length - 1];
+  const { typeId } = useParams();
+
+  if (!typeId) {
+    return null;
+  }
 
   const {
     recordIds,
     isLoading: isRecordIdsLoading,
     isError: isRecordIdsError,
-  } = useShmupRecordIds(endpointName);
+  } = useShmupRecordIds(typeId);
   const currentRecordId = useShmupRecordStore((state) => state.currentRecordId);
   const setCurrentRecordId = useShmupRecordStore(
     (state) => state.setCurrentRecordId
@@ -62,7 +62,7 @@ export function RecordPage() {
     recordArticle,
     isLoading: isRecordArticleLoading,
     isError: isRecordArticleError,
-  } = useShmupArticle(endpointName, currentRecordId);
+  } = useShmupArticle(typeId, currentRecordId);
 
   useEffect(() => {
     useShmupRecordStore

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,6 @@
 export interface NavNodeInfo {
   id: string;
+  linkTo?: string;
   childNavNodes?: NavNodeInfo[];
 }
 


### PR DESCRIPTION
- Use URL parameters instead of splitting `pathname`.
- Replaced hierarchical `linkTo`s in `NavItemTree` into nav-items' own ones. (still available only if it is a leaf)