### PR TITLE
refactor: rename index to nav-node & move month-title to texts

### DIFF
--- a/src/Main.tsx
+++ b/src/Main.tsx
@@ -4,7 +4,7 @@ import { Outlet } from 'react-router-dom';
 
 import { NavSidebar } from '^/components/organisms/NavSidebar';
 import { NavRouteTitle } from '^/components/atoms/NavRouteTitle';
-import { rootNavNodes } from '^/constants';
+import { rootNavNodes } from '^/constants/nav-node';
 
 const Root = styled.div`
   width: 100vw;

--- a/src/components/atoms/NavItemButton/index.test.tsx
+++ b/src/components/atoms/NavItemButton/index.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 
-import { navNodeInfoForTest } from '^/constants';
+import { navNodeInfoForTest } from '^/constants/nav-node';
 
 import { NavItemButton } from '.';
 

--- a/src/components/molecules/NavItemTree/index.test.tsx
+++ b/src/components/molecules/NavItemTree/index.test.tsx
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, it } from 'vitest';
 import { cleanup, render } from '@testing-library/react';
 import { RouterProvider, createMemoryRouter } from 'react-router-dom';
 
-import { navNodeInfoForTest } from '^/constants';
+import { navNodeInfoForTest } from '^/constants/nav-node';
 
 import { NavItemTree } from '.';
 

--- a/src/components/organisms/NavSidebar/index.test.tsx
+++ b/src/components/organisms/NavSidebar/index.test.tsx
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, it } from 'vitest';
 import { cleanup, render, screen } from '@testing-library/react';
 import { RouterProvider, createMemoryRouter } from 'react-router-dom';
 
-import { rootNavNodes } from '^/constants';
+import { rootNavNodes } from '^/constants/nav-node';
 import { texts } from '^/constants/texts';
 
 import { NavSidebar } from '.';

--- a/src/constants/nav-node.ts
+++ b/src/constants/nav-node.ts
@@ -52,18 +52,3 @@ export const rootNavNodes: NavNodeInfo[] = [
     ],
   },
 ];
-
-export const monthTitle = [
-  '1월',
-  '2월',
-  '3월',
-  '4월',
-  '5월',
-  '6월',
-  '7월',
-  '8월',
-  '9월',
-  '10월',
-  '11월',
-  '12월',
-];

--- a/src/constants/texts.ts
+++ b/src/constants/texts.ts
@@ -48,3 +48,18 @@ export const texts: Record<string, string> = {
   'world-record': '전국 TOP',
   'shop-record': '점포 TOP',
 };
+
+export const monthTitle = [
+  '1월',
+  '2월',
+  '3월',
+  '4월',
+  '5월',
+  '6월',
+  '7월',
+  '8월',
+  '9월',
+  '10월',
+  '11월',
+  '12월',
+];

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,4 @@
-import { monthTitle } from '^/constants';
+import { monthTitle } from '^/constants/texts';
 
 export function convertDateToString(date: Date) {
   return `${date.getFullYear()}년 ${


### PR DESCRIPTION
- Renamed `index.ts` in `constants` into `nav-node`, since it has only nav-node data.
- Moved `monthTitle` to `texts.ts` in `constants`. It seems about texts.