### PR TITLE
improvement: split root nav trees into columns & add record types

### DIFF
--- a/src/Main.tsx
+++ b/src/Main.tsx
@@ -11,7 +11,7 @@ const Root = styled.div`
   height: 100vh;
 
   display: grid;
-  grid-template-columns: 300px 1fr;
+  grid-template-columns: auto 1fr;
 `;
 
 function Main() {

--- a/src/components/molecules/NavigationForest/index.tsx
+++ b/src/components/molecules/NavigationForest/index.tsx
@@ -5,14 +5,30 @@ import { NavigationTree } from '^/components/molecules/NavigationTree';
 import { NavNodeInfo } from '^/types';
 
 const Root = styled.div`
+  height: 100%;
+
+  display: flex;
+  flex-direction: row;
+
+  padding-top: 16px;
+  padding-bottom: 16px;
+
+  overflow-x: hidden;
+  overflow-y: auto;
+`;
+
+const TreeContainer = styled.div`
   width: 300px;
   height: 100%;
+
+  border-right: 1px solid #ffffff;
 
   padding-left: 16px;
   padding-right: 16px;
 
-  overflow-x: hidden;
-  overflow-y: auto;
+  &:last-of-type {
+    border: none;
+  }
 `;
 
 interface Props {
@@ -21,7 +37,9 @@ interface Props {
 
 export function NavigationForest({ rootNavNodes }: Props) {
   const renderRootNavNodes = rootNavNodes.map((navNode) => (
-    <NavigationTree key={navNode.id} depth={0} nodeInfo={navNode} />
+    <TreeContainer key={navNode.id}>
+      <NavigationTree depth={0} nodeInfo={navNode} />
+    </TreeContainer>
   ));
 
   return <Root>{renderRootNavNodes}</Root>;

--- a/src/constants/nav-node.ts
+++ b/src/constants/nav-node.ts
@@ -46,12 +46,74 @@ export const rootNavNodes: NavNodeInfo[] = [
             linkTo: '/records/dodonpachi-ashot',
           },
           {
+            id: 'dodonpachi-alaser',
+            linkTo: '/records/dodonpachi-alaser',
+          },
+          {
+            id: 'dodonpachi-bshot',
+            linkTo: '/records/dodonpachi-bshot',
+          },
+          {
             id: 'dodonpachi-blaser',
             linkTo: '/records/dodonpachi-blaser',
           },
           {
             id: 'dodonpachi-cshot',
             linkTo: '/records/dodonpachi-cshot',
+          },
+          {
+            id: 'dodonpachi-claser',
+            linkTo: '/records/dodonpachi-claser',
+          },
+        ],
+      },
+      {
+        id: 'galagaarrangement',
+        linkTo: '/records/galagaarrangement',
+      },
+      {
+        id: 'dariusgaiden',
+        childNavNodes: [
+          {
+            id: 'dariusgaiden-zprime',
+            linkTo: '/records/dariusgaiden-zprime',
+          },
+          {
+            id: 'dariusgaiden-v',
+            linkTo: '/records/dariusgaiden-v',
+          },
+          {
+            id: 'dariusgaiden-w',
+            linkTo: '/records/dariusgaiden-w',
+          },
+          {
+            id: 'dariusgaiden-x',
+            linkTo: '/records/dariusgaiden-x',
+          },
+          {
+            id: 'dariusgaiden-y',
+            linkTo: '/records/dariusgaiden-y',
+          },
+          {
+            id: 'dariusgaiden-z',
+            linkTo: '/records/dariusgaiden-z',
+          },
+          {
+            id: 'dariusgaiden-vprime',
+            linkTo: '/records/dariusgaiden-vprime',
+          },
+        ],
+      },
+      {
+        id: 'ketsui',
+        childNavNodes: [
+          {
+            id: 'ketsui-a',
+            linkTo: '/records/ketsui-a',
+          },
+          {
+            id: 'ketsui-b',
+            linkTo: '/records/ketsui-b',
           },
         ],
       },

--- a/src/constants/nav-node.ts
+++ b/src/constants/nav-node.ts
@@ -23,12 +23,17 @@ export const navNodeInfoForTest: NavNodeInfo = {
 
 export const rootNavNodes: NavNodeInfo[] = [
   {
-    id: 'intro',
-    linkTo: '/intro',
-  },
-  {
-    id: 'criteria',
-    linkTo: '/criteria',
+    id: 'introduction',
+    childNavNodes: [
+      {
+        id: 'intro',
+        linkTo: '/intro',
+      },
+      {
+        id: 'criteria',
+        linkTo: '/criteria',
+      },
+    ],
   },
   {
     id: 'records',

--- a/src/constants/texts.ts
+++ b/src/constants/texts.ts
@@ -32,6 +32,9 @@ export const texts: Record<string, string> = {
   'dariusgaiden-z': 'Z존',
   // prettier-ignore
   'dariusgaiden-vprime': 'V\'존',
+  ketsui: '케츠이',
+  'ketsui-a': 'A타입',
+  'ketsui-b': 'B타입',
   /**
    * Method names
    */

--- a/src/constants/texts.ts
+++ b/src/constants/texts.ts
@@ -10,6 +10,7 @@ export const texts: Record<string, string> = {
   /**
    * Names for navigation, games, and subjects
    */
+  introduction: 'YSOShmupRecords 소개',
   intro: '개요',
   criteria: '등록 기준',
   records: '기록',

--- a/src/pages/RecordPage/index.tsx
+++ b/src/pages/RecordPage/index.tsx
@@ -32,6 +32,7 @@ const ArticleSkeletonArea = styled.div`
 
   display: flex;
   flex-direction: row;
+  flex-wrap: wrap;
   column-gap: 10px;
 
   & > div {


### PR DESCRIPTION
- Expanded sidebar width. (made sidebar width more flexible)
- Split root nav nodes in nav-forest into sidebar columns.
- Added vertical padding in nav-forest.
- Added record types for Galaga Arrangement, Darius Gaiden, and Ketsui.