### PR TITLE
improvement: change article layout into notion style & limit main outlet width up to 720px

### DIFF
--- a/src/Main.tsx
+++ b/src/Main.tsx
@@ -3,25 +3,30 @@ import styled from 'styled-components';
 import { Outlet } from 'react-router-dom';
 
 import { Sidebar } from '^/components/organisms/Sidebar';
-import { NavRouteTitle } from '^/components/atoms/NavRouteTitle';
 import { rootNavNodes } from '^/constants/nav-node';
 
 const Root = styled.div`
   width: 100vw;
   height: 100vh;
-
   display: grid;
   grid-template-columns: auto 1fr;
+`;
+
+const OutletWrapper = styled.div`
+  display: flex;
+  justify-content: center;
+  padding-top: 72px;
+  padding-bottom: 72px;
+  overflow-y: scroll;
 `;
 
 function Main() {
   return (
     <Root>
       <Sidebar rootNavNodes={rootNavNodes} />
-      <div>
-        <NavRouteTitle />
+      <OutletWrapper>
         <Outlet />
-      </div>
+      </OutletWrapper>
     </Root>
   );
 }

--- a/src/Main.tsx
+++ b/src/Main.tsx
@@ -12,7 +12,7 @@ const Root = styled.div`
   grid-template-columns: auto 1fr;
 `;
 
-const OutletWrapper = styled.div`
+const OutletPositionHolder = styled.div`
   display: flex;
   justify-content: center;
   padding-top: 72px;
@@ -20,13 +20,20 @@ const OutletWrapper = styled.div`
   overflow-y: scroll;
 `;
 
+const OutletContainer = styled.div`
+  width: 100%;
+  max-width: 720px;
+`;
+
 function Main() {
   return (
     <Root>
       <Sidebar rootNavNodes={rootNavNodes} />
-      <OutletWrapper>
-        <Outlet />
-      </OutletWrapper>
+      <OutletPositionHolder>
+        <OutletContainer>
+          <Outlet />
+        </OutletContainer>
+      </OutletPositionHolder>
     </Root>
   );
 }

--- a/src/components/atoms/NavRouteTitle/index.tsx
+++ b/src/components/atoms/NavRouteTitle/index.tsx
@@ -4,10 +4,6 @@ import styled from 'styled-components';
 
 import { texts } from '^/constants/texts';
 
-const Root = styled.nav`
-  padding: 10px 15px;
-`;
-
 const Crumbs = styled.ol`
   list-style-type: none;
   padding-left: 0;
@@ -15,8 +11,8 @@ const Crumbs = styled.ol`
 
 const CrumbItem = styled.li`
   display: inline-block;
-  font-size: 36px;
-  font-weight: 700;
+  font-size: 16px;
+  font-weight: 400;
 
   & + &::before {
     content: ' > ';
@@ -31,12 +27,12 @@ export function NavRouteTitle() {
     .filter((path) => path.length > 1);
 
   return pathNameSplit.length > 0 ? (
-    <Root>
+    <nav>
       <Crumbs>
         {pathNameSplit.map((navNodeId) => (
           <CrumbItem key={navNodeId}>{texts[navNodeId] ?? navNodeId}</CrumbItem>
         ))}
       </Crumbs>
-    </Root>
+    </nav>
   ) : null;
 }

--- a/src/components/atoms/Thumbnail/index.tsx
+++ b/src/components/atoms/Thumbnail/index.tsx
@@ -10,12 +10,15 @@ const Root = styled.button`
 
   padding: 0;
 
+  background-color: black;
+
   cursor: pointer;
 `;
 
 const Image = styled.img`
   width: inherit;
   height: inherit;
+  object-fit: contain;
 `;
 
 interface Props {

--- a/src/components/atoms/Thumbnail/index.tsx
+++ b/src/components/atoms/Thumbnail/index.tsx
@@ -5,8 +5,8 @@ const Root = styled.button`
   border: unset;
   background: unset;
 
-  width: 360px;
-  height: 360px;
+  width: 240px;
+  height: 240px;
 
   padding: 0;
 
@@ -14,10 +14,8 @@ const Root = styled.button`
 `;
 
 const Image = styled.img`
-  width: auto;
-  height: auto;
-  max-width: 360px;
-  max-height: 360px;
+  width: inherit;
+  height: inherit;
 `;
 
 interface Props {

--- a/src/components/molecules/ArticleExtra/index.test.tsx
+++ b/src/components/molecules/ArticleExtra/index.test.tsx
@@ -22,7 +22,7 @@ describe('ArticleExtra', () => {
   it('should show youtube when the record contains youtube link', () => {
     render(<ArticleExtra comment={comment} youtubeUrl={youtubeUrl} />);
 
-    const youtube = screen.getByText(/유튜브 링크/i);
+    const youtube = screen.getByText(/유튜브 영상/i);
     expect(youtube).not.toBeNull();
   });
 });

--- a/src/components/molecules/ArticleExtra/index.tsx
+++ b/src/components/molecules/ArticleExtra/index.tsx
@@ -3,25 +3,29 @@ import styled from 'styled-components';
 
 import { ShmupRecord } from '^/types';
 
-const Root = styled.div`
+const Root = styled.ul`
   width: 100%;
+  padding-left: 15px;
 `;
 
-const Column = styled.div`
+const ListItem = styled.li`
+  &:not(:last-of-type) {
+    margin-bottom: 8px;
+  }
+`;
+
+const ListItemWrapper = styled.div`
   display: flex;
-  flex-direction: row;
-  flex-wrap: wrap;
-  align-items: center;
-  column-gap: 15px;
+  flex-direction: column;
+  row-gap: 8px;
 `;
 
-const ColumnTitle = styled.div`
-  width: 180px;
-  font-weight: 600;
+const ListItemTitle = styled.span`
   font-size: 16px;
+  font-weight: 600;
 `;
 
-const ColumnContent = styled.div`
+const ListItemContent = styled.span`
   font-size: 16px;
   font-weight: 400;
 `;
@@ -32,33 +36,36 @@ interface Props {
 }
 
 export function ArticleExtra({ comment, youtubeUrl }: Props) {
-  /**
-   * @todo
-   * Expand youtube embed to maximum
-   */
   const renderYoutube =
     youtubeUrl !== undefined ? (
-      <Column>
-        <ColumnTitle>유튜브 링크</ColumnTitle>
-        <ColumnContent>
-          <iframe
-            width="100%"
-            height="100%"
-            src={youtubeUrl}
-            title="YouTube video player"
-            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-            allowFullScreen
-          />
-        </ColumnContent>
-      </Column>
+      <ListItem>
+        <ListItemWrapper>
+          <ListItemTitle>유튜브 영상</ListItemTitle>
+          <ListItemContent>
+            <iframe
+              width="100%"
+              height="480px"
+              src={youtubeUrl}
+              title="YouTube video player"
+              allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+              allowFullScreen
+              style={{
+                borderWidth: 0,
+              }}
+            />
+          </ListItemContent>
+        </ListItemWrapper>
+      </ListItem>
     ) : null;
 
   return (
     <Root>
-      <Column>
-        <ColumnTitle>코멘터리</ColumnTitle>
-        <ColumnContent>{comment}</ColumnContent>
-      </Column>
+      <ListItem>
+        <ListItemWrapper>
+          <ListItemTitle>코멘터리</ListItemTitle>
+          <ListItemContent>{comment}</ListItemContent>
+        </ListItemWrapper>
+      </ListItem>
       {renderYoutube}
     </Root>
   );

--- a/src/components/molecules/ArticleSummary/index.test.tsx
+++ b/src/components/molecules/ArticleSummary/index.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { beforeEach, describe, expect, it } from 'vitest';
 import { cleanup, render, screen } from '@testing-library/react';
 
+import { createMemoryRouter, RouterProvider } from 'react-router-dom';
 import { ShmupRecord } from '^/types';
 import { convertDateToString } from '^/utils/date-to-string';
 
@@ -17,7 +18,6 @@ const testDataWithoutSpecialTags: ShmupRecord = {
   comment: '야스오 2-4 진출',
   thumbnailUrl: 'Thumbnail URL',
   originalImageUrl: 'Original Image URL',
-  tweetUrl: 'Tweet URL',
 };
 
 const testDataWithSpecialTags: ShmupRecord = {
@@ -30,8 +30,28 @@ describe('ArticleSummary', () => {
     cleanup();
   });
 
-  it('should have thumbnail, date title, stage, score, method, and tweet link', () => {
-    render(<ArticleSummary record={testDataWithoutSpecialTags} />);
+  it('should have thumbnail, date title, stage, score, method', () => {
+    const routes = [
+      {
+        path: '/test-sub1/test/koishi/hoshino',
+        element: <ArticleSummary record={testDataWithoutSpecialTags} />,
+      },
+    ];
+
+    const router = createMemoryRouter(routes, {
+      initialEntries: ['/', '/test-sub1/test/koishi/hoshino'],
+      initialIndex: 1,
+    });
+
+    render(<RouterProvider router={router} />);
+
+    const renderResult1 = screen.getByText(/kuman514/i);
+    const renderResult2 = screen.getByText(/koishi/i);
+    const renderResult3 = screen.getByText(/hoshino/i);
+
+    expect(renderResult1).not.toStrictEqual(renderResult2);
+    expect(renderResult1).not.toStrictEqual(renderResult3);
+    expect(renderResult2).not.toStrictEqual(renderResult3);
 
     const thumbnail = screen.getByAltText(
       `${testDataWithoutSpecialTags.subjectId} ${convertDateToString(
@@ -55,13 +75,22 @@ describe('ArticleSummary', () => {
 
     const byWhat = screen.getByText(testDataWithoutSpecialTags.byWhat);
     expect(byWhat).not.toBeNull();
-
-    const tweetUrl = screen.getByText(testDataWithoutSpecialTags.tweetUrl);
-    expect(tweetUrl).not.toBeNull();
   });
 
   it('should show special tag area when the record have tags', () => {
-    render(<ArticleSummary record={testDataWithSpecialTags} />);
+    const routes = [
+      {
+        path: '/',
+        element: <ArticleSummary record={testDataWithSpecialTags} />,
+      },
+    ];
+
+    const router = createMemoryRouter(routes, {
+      initialEntries: ['/'],
+      initialIndex: 0,
+    });
+
+    render(<RouterProvider router={router} />);
 
     const specialTagTitle = screen.getByText(/특이사항/i);
     expect(specialTagTitle).not.toBeNull();

--- a/src/components/molecules/ArticleSummary/index.tsx
+++ b/src/components/molecules/ArticleSummary/index.tsx
@@ -6,14 +6,22 @@ import { Thumbnail } from '^/components/atoms/Thumbnail';
 import { convertDateToString } from '^/utils/date-to-string';
 import { texts } from '^/constants/texts';
 import { ImageDisplayModal } from '^/components/molecules/ImageDisplayModal';
+import { NavRouteTitle } from '^/components/atoms/NavRouteTitle';
 
 const Root = styled.div`
   width: 100%;
   display: flex;
-  flex-direction: row;
+  flex-direction: column;
   flex-wrap: wrap;
+  row-gap: 16px;
+`;
+
+const SummaryArea = styled.div`
+  display: flex;
+  flex-direction: row;
   align-items: center;
-  column-gap: 15px;
+  flex-wrap: wrap;
+  gap: 16px;
 `;
 
 const Title = styled.h1`
@@ -23,6 +31,10 @@ const Title = styled.h1`
 
 const List = styled.ul`
   padding-left: 15px;
+
+  & > li:not(:last-of-type) {
+    margin-bottom: 8px;
+  }
 `;
 
 const ListItemTitle = styled.span`
@@ -82,12 +94,6 @@ export function ArticleSummary({ record }: Props) {
           {texts[record.byWhat] ?? record.byWhat}
         </ListItemContent>
       </li>
-      <li>
-        <ListItemTitle>트위터 링크</ListItemTitle>
-        <ListItemContent>
-          <a href={record.tweetUrl}>{record.tweetUrl}</a>
-        </ListItemContent>
-      </li>
       {renderSpecialTags}
     </List>
   );
@@ -103,19 +109,20 @@ export function ArticleSummary({ record }: Props) {
 
   return (
     <Root>
-      <Thumbnail
-        imageSrc={record.thumbnailUrl}
-        altText={`${record.subjectId} ${convertDateToString(record.when)} ${
-          record.stage
-        }스테이지 ${record.score}점`}
-        onClick={() => {
-          setIsImageModalShow(true);
-        }}
-      />
-      <div>
-        <Title>{convertDateToString(record.when)}</Title>
-        {renderList}
-      </div>
+      <Title>{convertDateToString(record.when)}</Title>
+      <NavRouteTitle />
+      <SummaryArea>
+        <Thumbnail
+          imageSrc={record.thumbnailUrl}
+          altText={`${record.subjectId} ${convertDateToString(record.when)} ${
+            record.stage
+          }스테이지 ${record.score}점`}
+          onClick={() => {
+            setIsImageModalShow(true);
+          }}
+        />
+        <div>{renderList}</div>
+      </SummaryArea>
       {renderImageModal}
     </Root>
   );

--- a/src/components/molecules/ArticleSummary/index.tsx
+++ b/src/components/molecules/ArticleSummary/index.tsx
@@ -26,7 +26,7 @@ const SummaryArea = styled.div`
 
 const Title = styled.h1`
   font-size: 36px;
-  font-weight: 600;
+  font-weight: 700;
 `;
 
 const List = styled.ul`

--- a/src/components/organisms/Article/index.test.tsx
+++ b/src/components/organisms/Article/index.test.tsx
@@ -80,7 +80,7 @@ describe('Article', () => {
     const commentary = screen.getByText(testData.comment);
     expect(commentary).not.toBeNull();
 
-    const youtube = screen.getByText(/유튜브 링크/i);
+    const youtube = screen.getByText(/유튜브 영상/i);
     expect(youtube).not.toBeNull();
   });
 });

--- a/src/components/organisms/Article/index.test.tsx
+++ b/src/components/organisms/Article/index.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { beforeEach, describe, expect, it } from 'vitest';
 import { cleanup, render, screen } from '@testing-library/react';
 
+import { createMemoryRouter, RouterProvider } from 'react-router-dom';
 import { ShmupRecord } from '^/types';
 import { convertDateToString } from '^/utils/date-to-string';
 
@@ -17,7 +18,6 @@ const testData: ShmupRecord = {
   comment: '야스오 2-4 진출',
   thumbnailUrl: 'Thumbnail URL',
   originalImageUrl: 'Original Image URL',
-  tweetUrl: 'Tweet URL',
   specialTags: ['science', 'no miss'],
   youtubeUrl: 'Youtube URL',
 };
@@ -27,8 +27,28 @@ describe('Article', () => {
     cleanup();
   });
 
-  it('should have thumbnail, date title, stage, score, method, tweet link, special tag area, commentary, and youtube', () => {
-    render(<Article recordArticle={testData} />);
+  it('should have nav route title, thumbnail, date title, stage, score, method, special tag area, commentary, and youtube', () => {
+    const routes = [
+      {
+        path: '/test-sub1/test/koishi/hoshino',
+        element: <Article recordArticle={testData} />,
+      },
+    ];
+
+    const router = createMemoryRouter(routes, {
+      initialEntries: ['/', '/test-sub1/test/koishi/hoshino'],
+      initialIndex: 1,
+    });
+
+    render(<RouterProvider router={router} />);
+
+    const renderResult1 = screen.getByText(/kuman514/i);
+    const renderResult2 = screen.getByText(/koishi/i);
+    const renderResult3 = screen.getByText(/hoshino/i);
+
+    expect(renderResult1).not.toStrictEqual(renderResult2);
+    expect(renderResult1).not.toStrictEqual(renderResult3);
+    expect(renderResult2).not.toStrictEqual(renderResult3);
 
     const thumbnail = screen.getByAltText(
       `${testData.subjectId} ${convertDateToString(testData.when)} ${
@@ -48,9 +68,6 @@ describe('Article', () => {
 
     const byWhat = screen.getByText(testData.byWhat);
     expect(byWhat).not.toBeNull();
-
-    const tweetUrl = screen.getByText(testData.tweetUrl);
-    expect(tweetUrl).not.toBeNull();
 
     const specialTagTitle = screen.getByText(/특이사항/i);
     expect(specialTagTitle).not.toBeNull();

--- a/src/components/organisms/Article/index.tsx
+++ b/src/components/organisms/Article/index.tsx
@@ -7,7 +7,6 @@ import { ShmupRecord } from '^/types';
 
 const Root = styled.article`
   width: 100%;
-  max-width: 720px;
 
   display: flex;
   flex-direction: column;

--- a/src/components/organisms/Article/index.tsx
+++ b/src/components/organisms/Article/index.tsx
@@ -1,8 +1,18 @@
 import React from 'react';
+import styled from 'styled-components';
 
 import { ArticleSummary } from '^/components/molecules/ArticleSummary';
 import { ArticleExtra } from '^/components/molecules/ArticleExtra';
 import { ShmupRecord } from '^/types';
+
+const Root = styled.article`
+  width: 100%;
+  max-width: 720px;
+
+  display: flex;
+  flex-direction: column;
+  row-gap: 16px;
+`;
 
 interface Props {
   recordArticle: ShmupRecord;
@@ -10,12 +20,12 @@ interface Props {
 
 export function Article({ recordArticle }: Props) {
   return (
-    <article>
+    <Root>
       <ArticleSummary record={recordArticle} />
       <ArticleExtra
         comment={recordArticle.comment}
         youtubeUrl={recordArticle.youtubeUrl}
       />
-    </article>
+    </Root>
   );
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,7 +18,6 @@ export interface ShmupRecord {
   comment: string;
   thumbnailUrl: string;
   originalImageUrl: string;
-  tweetUrl: string;
   youtubeUrl?: string;
   specialTags?: string[];
 }


### PR DESCRIPTION
# Description

- Shrunken thumbnail's size into 240px.
- Moved nav route title component to subtitle for article.
- All outlet components will show in consistent width. (max 720px)
- Changed article layout into Notion style. (see below)

![image](https://github.com/kuman514/YSOShmupRecords/assets/12974660/f5ab9a70-81e8-4bb3-a7d8-0715cc6e65e6)
