### PR TITLE
refactor: move font-family value to global css

### DIFF
--- a/src/components/atoms/Avatar/__snapshots__/index.test.tsx.snap
+++ b/src/components/atoms/Avatar/__snapshots__/index.test.tsx.snap
@@ -13,7 +13,6 @@ exports[`TitleWithAvatar > should have a snapshot match for its appearance 1`] =
 
 .c1 {
   color: #000000;
-  font-family: Inter;
   font-size: 16px;
   font-weight: 500;
   border-radius: inherit;

--- a/src/components/atoms/Avatar/index.tsx
+++ b/src/components/atoms/Avatar/index.tsx
@@ -17,7 +17,7 @@ const Root = styled.div<RootProps>`
 
 const TmpPlaceholder = styled.img`
   color: #000000;
-  font-family: Inter;
+
   font-size: 16px;
   font-weight: 500;
 

--- a/src/components/atoms/Button/__snapshots__/index.test.tsx.snap
+++ b/src/components/atoms/Button/__snapshots__/index.test.tsx.snap
@@ -4,7 +4,6 @@ exports[`Sample test > should have a snapshot match for clear button 1`] = `
 .c0 {
   all: unset;
   box-sizing: border-box;
-  font-family: Inter;
   font-size: 16px;
   font-weight: 500;
   padding: 8px 16px;
@@ -38,7 +37,6 @@ exports[`Sample test > should have a snapshot match for disabled clear button 1`
 .c0 {
   all: unset;
   box-sizing: border-box;
-  font-family: Inter;
   font-size: 16px;
   font-weight: 500;
   padding: 8px 16px;
@@ -73,7 +71,6 @@ exports[`Sample test > should have a snapshot match for disabled line button 1`]
 .c0 {
   all: unset;
   box-sizing: border-box;
-  font-family: Inter;
   font-size: 16px;
   font-weight: 500;
   padding: 8px 16px;
@@ -108,7 +105,6 @@ exports[`Sample test > should have a snapshot match for disabled round line butt
 .c0 {
   all: unset;
   box-sizing: border-box;
-  font-family: Inter;
   font-size: 16px;
   font-weight: 500;
   padding: 8px 16px;
@@ -143,7 +139,6 @@ exports[`Sample test > should have a snapshot match for disabled round solid but
 .c0 {
   all: unset;
   box-sizing: border-box;
-  font-family: Inter;
   font-size: 16px;
   font-weight: 500;
   padding: 8px 16px;
@@ -178,7 +173,6 @@ exports[`Sample test > should have a snapshot match for disabled solid button 1`
 .c0 {
   all: unset;
   box-sizing: border-box;
-  font-family: Inter;
   font-size: 16px;
   font-weight: 500;
   padding: 8px 16px;
@@ -213,7 +207,6 @@ exports[`Sample test > should have a snapshot match for line button 1`] = `
 .c0 {
   all: unset;
   box-sizing: border-box;
-  font-family: Inter;
   font-size: 16px;
   font-weight: 500;
   padding: 8px 16px;
@@ -247,7 +240,6 @@ exports[`Sample test > should have a snapshot match for round line button 1`] = 
 .c0 {
   all: unset;
   box-sizing: border-box;
-  font-family: Inter;
   font-size: 16px;
   font-weight: 500;
   padding: 8px 16px;
@@ -281,7 +273,6 @@ exports[`Sample test > should have a snapshot match for round solid button 1`] =
 .c0 {
   all: unset;
   box-sizing: border-box;
-  font-family: Inter;
   font-size: 16px;
   font-weight: 500;
   padding: 8px 16px;
@@ -315,7 +306,6 @@ exports[`Sample test > should have a snapshot match for solid button 1`] = `
 .c0 {
   all: unset;
   box-sizing: border-box;
-  font-family: Inter;
   font-size: 16px;
   font-weight: 500;
   padding: 8px 16px;

--- a/src/components/atoms/Button/index.tsx
+++ b/src/components/atoms/Button/index.tsx
@@ -67,7 +67,6 @@ const Root = styled.button<RootProps>`
   all: unset;
   box-sizing: border-box;
 
-  font-family: Inter;
   font-size: 16px;
   font-weight: 500;
 

--- a/src/components/atoms/NavigationNode/index.tsx
+++ b/src/components/atoms/NavigationNode/index.tsx
@@ -12,7 +12,7 @@ interface RootProps {
 const Root = styled.div<RootProps>`
   & > * {
     color: #ffffff;
-    font-family: Inter;
+
     font-style: normal;
     line-height: normal;
 

--- a/src/components/molecules/RecordListCard/__snapshots__/index.test.tsx.snap
+++ b/src/components/molecules/RecordListCard/__snapshots__/index.test.tsx.snap
@@ -34,7 +34,6 @@ exports[`RecordListCard > should have a snapshot match for its appearance 1`] = 
 
 .c3 {
   color: #ffffff;
-  font-family: Inter;
   font-size: 16px;
   font-weight: 600;
 }

--- a/src/components/molecules/RecordListCard/index.tsx
+++ b/src/components/molecules/RecordListCard/index.tsx
@@ -41,7 +41,7 @@ const Summary = styled.div`
 
 const Title = styled.span`
   color: #ffffff;
-  font-family: Inter;
+
   font-size: 16px;
   font-weight: 600;
 `;

--- a/src/components/molecules/SidebarFooter/__snapshots__/index.test.tsx.snap
+++ b/src/components/molecules/SidebarFooter/__snapshots__/index.test.tsx.snap
@@ -4,7 +4,6 @@ exports[`SidebarFooter > should have a snapshot match for its appearance 1`] = `
 .c3 {
   all: unset;
   box-sizing: border-box;
-  font-family: Inter;
   font-size: 16px;
   font-weight: 500;
   padding: 8px 16px;

--- a/src/components/molecules/TitleWithAvatar/__snapshots__/index.test.tsx.snap
+++ b/src/components/molecules/TitleWithAvatar/__snapshots__/index.test.tsx.snap
@@ -13,7 +13,6 @@ exports[`TitleWithAvatar > should have a snapshot match for its appearance 1`] =
 
 .c3 {
   color: #000000;
-  font-family: Inter;
   font-size: 16px;
   font-weight: 500;
   border-radius: inherit;
@@ -37,7 +36,6 @@ exports[`TitleWithAvatar > should have a snapshot match for its appearance 1`] =
 
 .c4 {
   color: #ffffff;
-  font-family: Inter;
   font-size: 36px;
   font-weight: 200;
 }

--- a/src/components/molecules/TitleWithAvatar/index.tsx
+++ b/src/components/molecules/TitleWithAvatar/index.tsx
@@ -20,7 +20,7 @@ const Line = styled.div`
 
 const Title = styled.h1`
   color: #ffffff;
-  font-family: Inter;
+
   font-size: 36px;
   font-weight: 200;
 `;

--- a/src/global.css
+++ b/src/global.css
@@ -2,6 +2,7 @@
   box-sizing: border-box;
   margin: 0;
   font-size: 16px;
+  font-family: Inter, Arial, Helvetica, sans-serif;
 }
 
 :root {

--- a/src/pages/RecordListPage/index.tsx
+++ b/src/pages/RecordListPage/index.tsx
@@ -16,7 +16,7 @@ const Root = styled.div`
 
 const Title = styled.h1`
   color: var(--light-font-color);
-  font-family: Inter;
+
   font-size: 36px;
   font-weight: 700;
 `;


### PR DESCRIPTION
# Description

- Moved font-family value scattered in modules to global css.
- Added font-family in case of clients that doesn't have `Inter`.
