### PR TITLE
docs: split text items into ones for article and ones for navigation

### DIFF
--- a/src/components/atoms/NavRouteTitle/index.tsx
+++ b/src/components/atoms/NavRouteTitle/index.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { useLocation } from 'react-router-dom';
 import styled from 'styled-components';
 
-import { texts } from '^/constants/texts';
+import { textsForArticle } from '^/constants/texts';
 
 const Crumbs = styled.ol`
   list-style-type: none;
@@ -30,7 +30,9 @@ export function NavRouteTitle() {
     <nav>
       <Crumbs>
         {pathNameSplit.map((navNodeId) => (
-          <CrumbItem key={navNodeId}>{texts[navNodeId] ?? navNodeId}</CrumbItem>
+          <CrumbItem key={navNodeId}>
+            {textsForArticle[navNodeId] ?? navNodeId}
+          </CrumbItem>
         ))}
       </Crumbs>
     </nav>

--- a/src/components/atoms/NavigationNode/index.tsx
+++ b/src/components/atoms/NavigationNode/index.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 
 import { Link } from 'react-router-dom';
 import { NavNodeInfo } from '^/types';
-import { texts } from '^/constants/texts';
+import { textsForNavigation } from '^/constants/texts';
 
 interface RootProps {
   $url?: string;
@@ -55,7 +55,7 @@ interface Props {
 }
 
 export function NavigationNode({ depth, nodeInfo }: Props) {
-  const text = texts[nodeInfo.id] ?? nodeInfo.id;
+  const text = textsForNavigation[nodeInfo.id] ?? nodeInfo.id;
   const renderText = (() => {
     switch (depth) {
       case 0:

--- a/src/components/molecules/ArticleSummary/index.tsx
+++ b/src/components/molecules/ArticleSummary/index.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components';
 import { ShmupRecord } from '^/types';
 import { Thumbnail } from '^/components/atoms/Thumbnail';
 import { convertDateToString } from '^/utils/date-to-string';
-import { texts } from '^/constants/texts';
+import { textsForArticle } from '^/constants/texts';
 import { ImageDisplayModal } from '^/components/molecules/ImageDisplayModal';
 import { NavRouteTitle } from '^/components/atoms/NavRouteTitle';
 
@@ -91,7 +91,7 @@ export function ArticleSummary({ record }: Props) {
       <li>
         <ListItemTitle>수단/장소</ListItemTitle>
         <ListItemContent>
-          {texts[record.byWhat] ?? record.byWhat}
+          {textsForArticle[record.byWhat] ?? record.byWhat}
         </ListItemContent>
       </li>
       {renderSpecialTags}

--- a/src/components/molecules/NavigationForest/index.test.tsx
+++ b/src/components/molecules/NavigationForest/index.test.tsx
@@ -4,7 +4,7 @@ import { cleanup, render, screen } from '@testing-library/react';
 import { RouterProvider, createMemoryRouter } from 'react-router-dom';
 
 import { rootNavNodes } from '^/constants/nav-node';
-import { texts } from '^/constants/texts';
+import { textsForNavigation } from '^/constants/texts';
 
 import { NavigationForest } from '.';
 
@@ -30,7 +30,7 @@ describe('NavSidebar', () => {
 
     rootNavNodes.forEach((rootNavNode) => {
       expect(
-        screen.getByText(texts[rootNavNode.id] ?? rootNavNode.id)
+        screen.getByText(textsForNavigation[rootNavNode.id] ?? rootNavNode.id)
       ).not.toBeNull();
     });
   });

--- a/src/constants/texts.ts
+++ b/src/constants/texts.ts
@@ -1,4 +1,4 @@
-export const texts: Record<string, string> = {
+export const textsForNavigation: Record<string, string> = {
   /**
    * Texts for tests
    */
@@ -10,7 +10,7 @@ export const texts: Record<string, string> = {
   /**
    * Names for navigation, games, and subjects
    */
-  introduction: 'YSOShmupRecords 소개',
+  introduction: 'YSOShmupRecords',
   intro: '개요',
   criteria: '등록 기준',
   records: '기록',
@@ -35,11 +35,50 @@ export const texts: Record<string, string> = {
   ketsui: '케츠이',
   'ketsui-a': 'A타입',
   'ketsui-b': 'B타입',
+};
+
+export const textsForArticle: Record<string, string> = {
+  /**
+   * Texts for tests
+   */
+  test: 'kuman514',
+  'test-sub1': 'subitem1',
+  'test-sub2': 'subitem2',
+  'test-sub3': 'subitem3',
+  'test-sub4': 'subitem4',
+  /**
+   * Names for navigation, games, and subjects
+   */
+  intro: '개요',
+  criteria: '등록 기준',
+  records: '기록',
+  dodonpachi: '도돈파치 (1997)',
+  'dodonpachi-ashot': '도돈파치 (1997): A-Shot',
+  'dodonpachi-alaser': '도돈파치 (1997): A-Laser',
+  'dodonpachi-bshot': '도돈파치 (1997): B-Shot',
+  'dodonpachi-blaser': '도돈파치 (1997): B-Laser',
+  'dodonpachi-cshot': '도돈파치 (1997): C-Shot',
+  'dodonpachi-claser': '도돈파치 (1997): C-Laser',
+  galagaarrangement: '남코 클래식 콜렉션 Vol. 1: 갤러그 어레인지먼트',
+  dariusgaiden: '다라이어스 외전',
+  // prettier-ignore
+  'dariusgaiden-zprime': '다라이어스 외전: Z\'존',
+  'dariusgaiden-v': '다라이어스 외전: V존',
+  'dariusgaiden-w': '다라이어스 외전: W존',
+  'dariusgaiden-x': '다라이어스 외전: X존',
+  'dariusgaiden-y': '다라이어스 외전: Y존',
+  'dariusgaiden-z': '다라이어스 외전: Z존',
+  // prettier-ignore
+  'dariusgaiden-vprime': '다라이어스 외전: V\'존',
+  ketsui: '케츠이',
+  'ketsui-a': '케츠이: A타입',
+  'ketsui-b': '케츠이: B타입',
   /**
    * Method names
    */
   'arcade-akatronics': '아카트로닉스 실기체',
   'darius-cozmic-collection-steam': '스팀판 다라이어스 코즈믹 컬렉션',
+  'ketsui-deathtiny-ps4': 'PS4판 케츠이 Deathtiny',
   /**
    * Special tag names
    */

--- a/src/pages/RecordListPage/index.tsx
+++ b/src/pages/RecordListPage/index.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { useParams, Link } from 'react-router-dom';
 import styled from 'styled-components';
 
-import { texts } from '^/constants/texts';
+import { textsForArticle } from '^/constants/texts';
 import { useShmupRecordIds } from '^/hooks/useShmupRecordIds';
 import { Skeleton } from '^/components/atoms/Skeleton';
 import { RecordListCard } from '^/components/molecules/RecordListCard';
@@ -114,7 +114,7 @@ export function RecordListPage() {
 
   return (
     <Root>
-      <Title>{texts[typeId] ?? typeId} 기록 목록</Title>
+      <Title>{textsForArticle[typeId] ?? typeId} 기록 목록</Title>
       {renderRecordIdSelection}
     </Root>
   );


### PR DESCRIPTION
# Description

- Split text items into ones for article and ones for navigation.
- Titles for article, such as `C-Shot 기록 목록`, lacked showing what game the record type talks about. So, this PR will show the game name as well, like `도돈파치(1997): C-Shot 기록 목록`.
