### PR TITLE
refactor: solve warnings about props

### DIFF
--- a/src/components/atoms/Skeleton/index.tsx
+++ b/src/components/atoms/Skeleton/index.tsx
@@ -7,9 +7,9 @@ import styled, { CSSProp } from 'styled-components';
  */
 
 interface RootProps {
-  width?: CSSProp;
-  height?: CSSProp;
-  borderRadius?: CSSProp;
+  $width?: CSSProp;
+  $height?: CSSProp;
+  $borderRadius?: CSSProp;
 }
 
 const Root = styled.div<RootProps>`
@@ -36,14 +36,18 @@ const Root = styled.div<RootProps>`
 
   overflow: hidden;
   position: relative;
-  width: ${({ width }) => width};
-  height: ${({ height }) => height};
-  border-radius: ${({ borderRadius }) => borderRadius};
+  width: ${({ $width }) => $width};
+  height: ${({ $height }) => $height};
+  border-radius: ${({ $borderRadius }) => $borderRadius};
   background: #e2e2e2;
 `;
 
-interface Props extends RootProps {}
+interface Props {
+  width: CSSProp;
+  height: CSSProp;
+  borderRadius: CSSProp;
+}
 
 export function Skeleton({ width, height, borderRadius }: Props) {
-  return <Root width={width} height={height} borderRadius={borderRadius} />;
+  return <Root $width={width} $height={height} $borderRadius={borderRadius} />;
 }

--- a/src/components/atoms/Skeleton/index.tsx
+++ b/src/components/atoms/Skeleton/index.tsx
@@ -43,9 +43,9 @@ const Root = styled.div<RootProps>`
 `;
 
 interface Props {
-  width: CSSProp;
-  height: CSSProp;
-  borderRadius: CSSProp;
+  width?: CSSProp;
+  height?: CSSProp;
+  borderRadius?: CSSProp;
 }
 
 export function Skeleton({ width, height, borderRadius }: Props) {

--- a/src/pages/RecordListPage/index.tsx
+++ b/src/pages/RecordListPage/index.tsx
@@ -83,7 +83,7 @@ export function RecordListPage() {
       {recordIds.length > 0 ? (
         <RecordSelectionList>
           {recordIds.map((recordId) => (
-            <li>
+            <li key={recordId}>
               <RecordSelectionLink to={`${recordId}`}>
                 <RecordListCard
                   imageUrl={getAPIURL(


### PR DESCRIPTION
# Description

- Solved warnings about `key` props in `RecordSelectionList`'s `map` function.
- Add `$` prefix in `Skeleton`'s `RootProps` to stop trying to recognize them.