### PR TITLE
improvement: support portrait and return to title with avatar on click link

### DIFF
--- a/src/Main.tsx
+++ b/src/Main.tsx
@@ -10,6 +10,12 @@ const Root = styled.div`
   height: 100vh;
   display: grid;
   grid-template-columns: auto 1fr;
+
+  @media (max-width: 1000px) {
+    height: auto;
+    display: flex;
+    flex-direction: column;
+  }
 `;
 
 const OutletPositionHolder = styled.div`

--- a/src/components/atoms/NavigationNode/index.tsx
+++ b/src/components/atoms/NavigationNode/index.tsx
@@ -46,7 +46,8 @@ const Root = styled.div<RootProps>`
 `;
 
 const NoUnderlineLinkOnNotHover = styled(Link)`
-  text-decoration: none;
+  all: inherit;
+  cursor: pointer;
 `;
 
 interface Props {
@@ -56,26 +57,27 @@ interface Props {
 
 export function NavigationNode({ depth, nodeInfo }: Props) {
   const text = textsForNavigation[nodeInfo.id] ?? nodeInfo.id;
-  const renderText = (() => {
+  const renderLinkText =
+    nodeInfo.linkTo !== undefined ? (
+      <NoUnderlineLinkOnNotHover to={nodeInfo.linkTo}>
+        {text}
+      </NoUnderlineLinkOnNotHover>
+    ) : (
+      text
+    );
+
+  const renderMainBody = (() => {
     switch (depth) {
       case 0:
-        return <h2>{text}</h2>;
+        return <h2>{renderLinkText}</h2>;
       case 1:
-        return <h3>{text}</h3>;
+        return <h3>{renderLinkText}</h3>;
       case 2:
-        return <span>{text}</span>;
+        return <span>{renderLinkText}</span>;
       default:
         return null;
     }
   })();
 
-  const renderMainBody = <Root $url={nodeInfo.linkTo}>{renderText}</Root>;
-
-  return nodeInfo.linkTo !== undefined ? (
-    <NoUnderlineLinkOnNotHover to={nodeInfo.linkTo}>
-      {renderMainBody}
-    </NoUnderlineLinkOnNotHover>
-  ) : (
-    renderMainBody
-  );
+  return <Root $url={nodeInfo.linkTo}>{renderMainBody}</Root>;
 }

--- a/src/components/molecules/NavigationForest/index.test.tsx
+++ b/src/components/molecules/NavigationForest/index.test.tsx
@@ -1,31 +1,36 @@
 import React from 'react';
-import { beforeEach, describe, expect, it } from 'vitest';
-import { cleanup, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { RouterProvider, createMemoryRouter } from 'react-router-dom';
 
-import { rootNavNodes } from '^/constants/nav-node';
+import { navNodeInfoForTest, rootNavNodes } from '^/constants/nav-node';
 import { textsForNavigation } from '^/constants/texts';
 
 import { NavigationForest } from '.';
 
 describe('NavSidebar', () => {
-  const routes = [
-    {
-      path: '/',
-      element: <NavigationForest rootNavNodes={rootNavNodes} />,
-    },
-  ];
-
-  const router = createMemoryRouter(routes, {
-    initialEntries: ['/'],
-    initialIndex: 0,
-  });
-
   beforeEach(() => {
     cleanup();
   });
 
   it('should show root nav nodes on init', () => {
+    const routes = [
+      {
+        path: '/',
+        element: (
+          <NavigationForest
+            onClickNavigationNode={() => {}}
+            rootNavNodes={rootNavNodes}
+          />
+        ),
+      },
+    ];
+
+    const router = createMemoryRouter(routes, {
+      initialEntries: ['/'],
+      initialIndex: 0,
+    });
+
     render(<RouterProvider router={router} />);
 
     rootNavNodes.forEach((rootNavNode) => {
@@ -33,5 +38,42 @@ describe('NavSidebar', () => {
         screen.getByText(textsForNavigation[rootNavNode.id] ?? rootNavNode.id)
       ).not.toBeNull();
     });
+  });
+
+  it('should invoke onClickNavigationNode on click anchor', async () => {
+    const mockFn = vi.fn();
+    const routes = [
+      {
+        path: '/',
+        element: (
+          <NavigationForest
+            onClickNavigationNode={mockFn}
+            rootNavNodes={[navNodeInfoForTest]}
+          />
+        ),
+      },
+      {
+        path: '/kuman514',
+        element: (
+          <NavigationForest
+            onClickNavigationNode={mockFn}
+            rootNavNodes={[navNodeInfoForTest]}
+          />
+        ),
+      },
+    ];
+
+    const router = createMemoryRouter(routes, {
+      initialEntries: ['/', '/kuman514'],
+      initialIndex: 0,
+    });
+
+    render(<RouterProvider router={router} />);
+
+    fireEvent.click(await screen.findByText(/subitem4/i));
+    expect(mockFn).toBeCalledTimes(1);
+
+    fireEvent.click(await screen.findByText(/subitem3/i));
+    expect(mockFn).toBeCalledTimes(1);
   });
 });

--- a/src/components/molecules/NavigationForest/index.tsx
+++ b/src/components/molecules/NavigationForest/index.tsx
@@ -39,14 +39,31 @@ const TreeContainer = styled.div`
 
 interface Props {
   rootNavNodes: NavNodeInfo[];
+  onClickNavigationNode(): void;
 }
 
-export function NavigationForest({ rootNavNodes }: Props) {
+export function NavigationForest({
+  rootNavNodes,
+  onClickNavigationNode,
+}: Props) {
   const renderRootNavNodes = rootNavNodes.map((navNode) => (
     <TreeContainer key={navNode.id}>
       <NavigationTree depth={0} nodeInfo={navNode} />
     </TreeContainer>
   ));
 
-  return <Root>{renderRootNavNodes}</Root>;
+  return (
+    <Root
+      onClick={(event) => {
+        if (
+          event.target instanceof HTMLElement &&
+          event.target.nodeName === 'A'
+        ) {
+          onClickNavigationNode();
+        }
+      }}
+    >
+      {renderRootNavNodes}
+    </Root>
+  );
 }

--- a/src/components/molecules/NavigationForest/index.tsx
+++ b/src/components/molecules/NavigationForest/index.tsx
@@ -12,6 +12,10 @@ const Root = styled.div`
 
   overflow-x: hidden;
   overflow-y: auto;
+
+  @media (max-width: 1000px) {
+    flex-direction: column;
+  }
 `;
 
 const TreeContainer = styled.div`
@@ -25,6 +29,11 @@ const TreeContainer = styled.div`
 
   &:last-of-type {
     border: none;
+  }
+
+  @media (max-width: 1000px) {
+    width: min(300px, 100%);
+    border-right: none;
   }
 `;
 

--- a/src/components/molecules/SidebarFooter/__snapshots__/index.test.tsx.snap
+++ b/src/components/molecules/SidebarFooter/__snapshots__/index.test.tsx.snap
@@ -29,8 +29,10 @@ exports[`SidebarFooter > should have a snapshot match for its appearance 1`] = `
 .c0 {
   display: flex;
   flex-direction: row;
+  flex-wrap: wrap;
   justify-content: center;
   align-items: center;
+  row-gap: 8px;
   column-gap: 20px;
   padding: 16px 16px 16px 32px;
   color: #ffffff;

--- a/src/components/molecules/SidebarFooter/index.tsx
+++ b/src/components/molecules/SidebarFooter/index.tsx
@@ -7,9 +7,11 @@ import { ButtonType } from '^/types';
 const Root = styled.div`
   display: flex;
   flex-direction: row;
+  flex-wrap: wrap;
   justify-content: center;
   align-items: center;
 
+  row-gap: 8px;
   column-gap: 20px;
   padding: 16px 16px 16px 32px;
 

--- a/src/components/organisms/Sidebar/index.tsx
+++ b/src/components/organisms/Sidebar/index.tsx
@@ -8,12 +8,19 @@ import { SidebarHeader } from '^/components/molecules/SidebarHeader';
 import { TitleWithAvatar } from '^/components/molecules/TitleWithAvatar';
 
 const Root = styled.div`
-  height: 100vh;
+  height: 100%;
 
   display: grid;
   grid-template-rows: auto 1fr auto;
 
   background: var(--primary-color);
+`;
+
+const CenterWrapper = styled.div`
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
 `;
 
 interface Props {
@@ -37,7 +44,7 @@ export function Sidebar({ rootNavNodes }: Props) {
           setIsNavigationOpen(!isNavigationOpen);
         }}
       />
-      {renderCenter}
+      <CenterWrapper>{renderCenter}</CenterWrapper>
       <SidebarFooter />
     </Root>
   );

--- a/src/components/organisms/Sidebar/index.tsx
+++ b/src/components/organisms/Sidebar/index.tsx
@@ -31,7 +31,12 @@ export function Sidebar({ rootNavNodes }: Props) {
   const [isNavigationOpen, setIsNavigationOpen] = useState<boolean>(false);
 
   const renderCenter = isNavigationOpen ? (
-    <NavigationForest rootNavNodes={rootNavNodes} />
+    <NavigationForest
+      onClickNavigationNode={() => {
+        setIsNavigationOpen(false);
+      }}
+      rootNavNodes={rootNavNodes}
+    />
   ) : (
     <TitleWithAvatar />
   );


### PR DESCRIPTION
# Description

- The app will go into portrait mode when `width <= 1000px`.
  - The sidebar will change into the header on portrait.
  - The sidebar(header) will change its `height`.
  - The navigation will change `flex-direction` into `column`.
  - The sidebar(header)'s footer will wrap when the window's width is too narrow.
- Recommended minimum width will be `300px`.
- The sidebar will be return to the title with avatar on click a navigation link.
