### PR TITLE
fix: stop img request on switch type-id path parameter

### DIFF
--- a/src/hooks/useShmupRecordIds.ts
+++ b/src/hooks/useShmupRecordIds.ts
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react';
 import { getAPIURL } from '^/utils/api-url';
 
 export function useShmupRecordIds(endpointName: string) {
+  const [savedTypeId, setSavedTypeId] = useState<string>('');
   const [recordIds, setRecordIds] = useState<string[]>([]);
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [isError, setIsError] = useState<boolean>(false);
@@ -13,6 +14,7 @@ export function useShmupRecordIds(endpointName: string) {
       setRecordIds([]);
       setIsError(false);
       setIsLoading(true);
+
       try {
         const response = await axios.get<string[]>(
           getAPIURL('records', endpointName, 'selection')
@@ -24,11 +26,17 @@ export function useShmupRecordIds(endpointName: string) {
           setIsError(true);
         }
       }
+
+      /**
+       * Save shmup record list type id after the request ended
+       */
+      setSavedTypeId(endpointName);
       setIsLoading(false);
     })();
   }, [endpointName]);
 
   return {
+    savedTypeId,
     recordIds,
     isLoading,
     isError,

--- a/src/hooks/useShmupRecordList.ts
+++ b/src/hooks/useShmupRecordList.ts
@@ -3,7 +3,7 @@ import { useEffect, useState } from 'react';
 
 import { getAPIURL } from '^/utils/api-url';
 
-export function useShmupRecordIds(endpointName: string) {
+export function useShmupRecordList(endpointName: string) {
   const [savedTypeId, setSavedTypeId] = useState<string>('');
   const [recordIds, setRecordIds] = useState<string[]>([]);
   const [isLoading, setIsLoading] = useState<boolean>(false);

--- a/src/pages/RecordListPage/index.tsx
+++ b/src/pages/RecordListPage/index.tsx
@@ -3,7 +3,7 @@ import { useParams, Link } from 'react-router-dom';
 import styled from 'styled-components';
 
 import { textsForArticle } from '^/constants/texts';
-import { useShmupRecordIds } from '^/hooks/useShmupRecordIds';
+import { useShmupRecordList } from '^/hooks/useShmupRecordList';
 import { Skeleton } from '^/components/atoms/Skeleton';
 import { RecordListCard } from '^/components/molecules/RecordListCard';
 import { convertDateToString } from '^/utils/date-to-string';
@@ -77,7 +77,7 @@ export function RecordListPage() {
     recordIds,
     isLoading: isRecordIdsLoading,
     isError: isRecordIdsError,
-  } = useShmupRecordIds(typeId);
+  } = useShmupRecordList(typeId);
 
   const renderRecordIdSelection = !isRecordIdsLoading ? (
     <RecordSelectionArea>

--- a/src/pages/RecordListPage/index.tsx
+++ b/src/pages/RecordListPage/index.tsx
@@ -73,6 +73,7 @@ export function RecordListPage() {
   }
 
   const {
+    savedTypeId,
     recordIds,
     isLoading: isRecordIdsLoading,
     isError: isRecordIdsError,
@@ -88,7 +89,7 @@ export function RecordListPage() {
                 <RecordListCard
                   imageUrl={getAPIURL(
                     'records',
-                    typeId,
+                    savedTypeId,
                     'images',
                     `${recordId}_thumbnail.jpg`
                   )}


### PR DESCRIPTION
# Description

- Before this PR, every time right after switching path paremeter `typeId`, lots of unnecessary image URL newly creates and gets lots of 404 errors.
- For example, right after switching `typeId` from `ketsui-b` to `dodonpachi-cshot`, image URLs unnecessarily became `/records/dodonpachi-cshot/:recordId/images/:recordId_thumbnail.jpg` and multiple 404s invoked.
<img width="739" alt="unnecessary img urls and 404s after switching ketsui-b to dodonpachi-cshot" src="https://github.com/kuman514/YSOShmupRecords/assets/12974660/5b54d733-bf61-4b67-80f0-6d50c4f95ab6">
- This PR keeps `typeId` using `savedTypeId` in the hook that gets shmup record ids' list until finishes request.
