### PR TITLE
fix: make title of intro consistent

### DIFF
--- a/src/components/atoms/NavRouteTitle/index.test.tsx
+++ b/src/components/atoms/NavRouteTitle/index.test.tsx
@@ -94,6 +94,6 @@ describe('NavRouteTitle', () => {
 
     render(<RouterProvider router={router} />);
 
-    expect(screen.queryByText(/개요/i)).toBeNull();
+    expect(screen.queryByText(/인삿말/i)).toBeNull();
   });
 });

--- a/src/constants/texts.ts
+++ b/src/constants/texts.ts
@@ -11,7 +11,7 @@ export const textsForNavigation: Record<string, string> = {
    * Names for navigation, games, and subjects
    */
   introduction: 'YSOShmupRecords',
-  intro: '개요',
+  intro: '인삿말',
   criteria: '등록 기준',
   records: '기록',
   terminology: '용어',
@@ -50,7 +50,7 @@ export const textsForArticle: Record<string, string> = {
   /**
    * Names for navigation, games, and subjects
    */
-  intro: '개요',
+  intro: '인삿말',
   criteria: '등록 기준',
   records: '기록',
   terminology: '용어',


### PR DESCRIPTION
# Description

- Changed `개요` into `인삿말` to make a consistent nav node name.
