### PR TITLE
fix: show article title area on load or error

### DIFF
--- a/src/components/molecules/ArticleSummary/index.test.tsx
+++ b/src/components/molecules/ArticleSummary/index.test.tsx
@@ -45,14 +45,6 @@ describe('ArticleSummary', () => {
 
     render(<RouterProvider router={router} />);
 
-    const renderResult1 = screen.getByText(/kuman514/i);
-    const renderResult2 = screen.getByText(/koishi/i);
-    const renderResult3 = screen.getByText(/hoshino/i);
-
-    expect(renderResult1).not.toStrictEqual(renderResult2);
-    expect(renderResult1).not.toStrictEqual(renderResult3);
-    expect(renderResult2).not.toStrictEqual(renderResult3);
-
     const thumbnail = screen.getByAltText(
       `${testDataWithoutSpecialTags.subjectId} ${convertDateToString(
         testDataWithoutSpecialTags.when
@@ -61,11 +53,6 @@ describe('ArticleSummary', () => {
       }점`
     );
     expect(thumbnail).not.toBeNull();
-
-    const dateTitle = screen.getByText(
-      convertDateToString(testDataWithoutSpecialTags.when)
-    );
-    expect(dateTitle).not.toBeNull();
 
     const stage = screen.getByText(testDataWithoutSpecialTags.stage);
     expect(stage).not.toBeNull();

--- a/src/components/molecules/ArticleSummary/index.tsx
+++ b/src/components/molecules/ArticleSummary/index.tsx
@@ -6,30 +6,16 @@ import { Thumbnail } from '^/components/atoms/Thumbnail';
 import { convertDateToString } from '^/utils/date-to-string';
 import { textsForArticle } from '^/constants/texts';
 import { ImageDisplayModal } from '^/components/molecules/ImageDisplayModal';
-import { NavRouteTitle } from '^/components/atoms/NavRouteTitle';
 import { Button } from '^/components/atoms/Button';
 import { ReactComponent as RawLinkSvg } from '^/assets/icons/link.svg';
 import { ReactComponent as RawTwitterSvg } from '^/assets/icons/twitter.svg';
 
 const Root = styled.div`
-  width: 100%;
-  display: flex;
-  flex-direction: column;
-  flex-wrap: wrap;
-  row-gap: 16px;
-`;
-
-const SummaryArea = styled.div`
   display: flex;
   flex-direction: row;
   align-items: center;
   flex-wrap: wrap;
   gap: 16px;
-`;
-
-const Title = styled.h1`
-  font-size: 36px;
-  font-weight: 700;
 `;
 
 const SummaryDescription = styled.div`
@@ -205,10 +191,8 @@ export function ArticleSummary({ record }: Props) {
   }, [isCopiedToClipboard]);
 
   return (
-    <Root>
-      <Title>{convertDateToString(record.when)}</Title>
-      <NavRouteTitle />
-      <SummaryArea>
+    <>
+      <Root>
         <Thumbnail
           imageSrc={record.thumbnailUrl}
           altText={`${record.subjectId} ${convertDateToString(record.when)} ${
@@ -241,8 +225,8 @@ export function ArticleSummary({ record }: Props) {
             </Button>
           </ShareButtonList>
         </SummaryDescription>
-      </SummaryArea>
+      </Root>
       {renderImageModal}
-    </Root>
+    </>
   );
 }

--- a/src/components/organisms/Article/index.test.tsx
+++ b/src/components/organisms/Article/index.test.tsx
@@ -27,7 +27,7 @@ describe('Article', () => {
     cleanup();
   });
 
-  it('should have nav route title, thumbnail, date title, stage, score, method, special tag area, commentary, and youtube', () => {
+  it('should have thumbnail, date title, stage, score, method, special tag area, commentary, and youtube', () => {
     const routes = [
       {
         path: '/test-sub1/test/koishi/hoshino',
@@ -42,23 +42,12 @@ describe('Article', () => {
 
     render(<RouterProvider router={router} />);
 
-    const renderResult1 = screen.getByText(/kuman514/i);
-    const renderResult2 = screen.getByText(/koishi/i);
-    const renderResult3 = screen.getByText(/hoshino/i);
-
-    expect(renderResult1).not.toStrictEqual(renderResult2);
-    expect(renderResult1).not.toStrictEqual(renderResult3);
-    expect(renderResult2).not.toStrictEqual(renderResult3);
-
     const thumbnail = screen.getByAltText(
       `${testData.subjectId} ${convertDateToString(testData.when)} ${
         testData.stage
       }스테이지 ${testData.score}점`
     );
     expect(thumbnail).not.toBeNull();
-
-    const dateTitle = screen.getByText(convertDateToString(testData.when));
-    expect(dateTitle).not.toBeNull();
 
     const stage = screen.getByText(testData.stage);
     expect(stage).not.toBeNull();

--- a/src/pages/RecordPage/index.tsx
+++ b/src/pages/RecordPage/index.tsx
@@ -6,15 +6,31 @@ import { Article } from '^/components/organisms/Article';
 import { useShmupArticle } from '^/hooks/useShmupArticle';
 import { Skeleton } from '^/components/atoms/Skeleton';
 import { ErrorIndicator } from '^/components/molecules/ErrorIndicator';
+import { NavRouteTitle } from '^/components/atoms/NavRouteTitle';
+import { convertDateToString } from '^/utils/date-to-string';
 
 const Root = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
   padding-left: 15px;
   padding-right: 15px;
+  row-gap: 16px;
+`;
+
+const TitleArea = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  row-gap: 16px;
+`;
+
+const Title = styled.h1`
+  font-size: 36px;
+  font-weight: 700;
 `;
 
 const ArticleSkeletonArea = styled.div`
-  margin-top: 15px;
-
   display: flex;
   flex-direction: row;
   flex-wrap: wrap;
@@ -31,7 +47,7 @@ const ArticleSkeletonArea = styled.div`
 export function RecordPage() {
   const { typeId, currentRecordId } = useParams();
 
-  if (!typeId) {
+  if (!typeId || !currentRecordId) {
     return null;
   }
   const { recordArticle, isLoading, isError } = useShmupArticle(
@@ -64,5 +80,13 @@ export function RecordPage() {
     return <Article recordArticle={recordArticle} />;
   })();
 
-  return <Root>{renderMainPart}</Root>;
+  return (
+    <Root>
+      <TitleArea>
+        <Title>{convertDateToString(new Date(currentRecordId))}</Title>
+        <NavRouteTitle />
+      </TitleArea>
+      {renderMainPart}
+    </Root>
+  );
 }


### PR DESCRIPTION
# Description

- Move title area out of `ArticleSummary`.
- This PR will show title regardless to on-load or on-error situation.
