### PR TITLE
improvement: add how many records a type has

### DIFF
--- a/src/components/organisms/RecordSelection/__snapshots__/index.test.tsx.snap
+++ b/src/components/organisms/RecordSelection/__snapshots__/index.test.tsx.snap
@@ -83,7 +83,7 @@ exports[`RecordSelection > should match snapshot with empty recordIds 1`] = `
 `;
 
 exports[`RecordSelection > should match snapshot with non-empty recordIds 1`] = `
-.c3 {
+.c4 {
   width: 300px;
   height: 240px;
   display: grid;
@@ -92,11 +92,11 @@ exports[`RecordSelection > should match snapshot with non-empty recordIds 1`] = 
   border-radius: 16px;
 }
 
-.c3:hover {
+.c4:hover {
   background-color: var(--hovering-color);
 }
 
-.c4 {
+.c5 {
   width: 100%;
   height: 100%;
   object-fit: cover;
@@ -104,7 +104,7 @@ exports[`RecordSelection > should match snapshot with non-empty recordIds 1`] = 
   border-top-right-radius: 16px;
 }
 
-.c5 {
+.c6 {
   height: 100%;
   display: flex;
   flex-direction: column;
@@ -114,7 +114,7 @@ exports[`RecordSelection > should match snapshot with non-empty recordIds 1`] = 
   align-items: flex-start;
 }
 
-.c6 {
+.c7 {
   color: #ffffff;
   font-size: 16px;
   font-weight: 600;
@@ -128,6 +128,12 @@ exports[`RecordSelection > should match snapshot with non-empty recordIds 1`] = 
 }
 
 .c1 {
+  font-size: 16px;
+  font-weight: 400;
+}
+
+.c2 {
+  width: 100%;
   display: flex;
   flex-direction: row;
   flex-wrap: wrap;
@@ -136,7 +142,7 @@ exports[`RecordSelection > should match snapshot with non-empty recordIds 1`] = 
   gap: 16px;
 }
 
-.c2 {
+.c3 {
   color: unset;
   text-decoration: none;
 }
@@ -144,26 +150,33 @@ exports[`RecordSelection > should match snapshot with non-empty recordIds 1`] = 
 <div
   class="c0"
 >
-  <div
+  <span
     class="c1"
   >
+    총 
+    3
+    건의 기록이 있습니다.
+  </span>
+  <div
+    class="c2"
+  >
     <a
-      class="c2"
+      class="c3"
       href="/2023-10-28"
     >
       <div
-        class="c3"
+        class="c4"
       >
         <img
           alt="2023년 10월 28일"
-          class="c4"
+          class="c5"
           src="2023-10-28.jpg"
         />
         <div
-          class="c5"
+          class="c6"
         >
           <span
-            class="c6"
+            class="c7"
           >
             2023년 10월 28일
           </span>
@@ -171,22 +184,22 @@ exports[`RecordSelection > should match snapshot with non-empty recordIds 1`] = 
       </div>
     </a>
     <a
-      class="c2"
+      class="c3"
       href="/2023-05-14"
     >
       <div
-        class="c3"
+        class="c4"
       >
         <img
           alt="2023년 5월 14일"
-          class="c4"
+          class="c5"
           src="2023-05-14.jpg"
         />
         <div
-          class="c5"
+          class="c6"
         >
           <span
-            class="c6"
+            class="c7"
           >
             2023년 5월 14일
           </span>
@@ -194,22 +207,22 @@ exports[`RecordSelection > should match snapshot with non-empty recordIds 1`] = 
       </div>
     </a>
     <a
-      class="c2"
+      class="c3"
       href="/2022-11-21"
     >
       <div
-        class="c3"
+        class="c4"
       >
         <img
           alt="2022년 11월 21일"
-          class="c4"
+          class="c5"
           src="2022-11-21.jpg"
         />
         <div
-          class="c5"
+          class="c6"
         >
           <span
-            class="c6"
+            class="c7"
           >
             2022년 11월 21일
           </span>

--- a/src/components/organisms/RecordSelection/index.tsx
+++ b/src/components/organisms/RecordSelection/index.tsx
@@ -13,7 +13,13 @@ const Root = styled.div`
   gap: 16px;
 `;
 
+const RecordCount = styled.span`
+  font-size: 16px;
+  font-weight: 400;
+`;
+
 const RecordSelectionList = styled.div`
+  width: 100%;
   display: flex;
   flex-direction: row;
   flex-wrap: wrap;
@@ -32,12 +38,13 @@ interface Props {
 }
 
 export function RecordSelection({ recordPreviews }: Props) {
-  const renderRecordSelectionArea = (() => {
-    if (recordPreviews.length === 0) {
-      return <EmptyIndicator />;
-    }
+  const renderRecordCount =
+    recordPreviews.length > 0 ? (
+      <RecordCount>총 {recordPreviews.length}건의 기록이 있습니다.</RecordCount>
+    ) : null;
 
-    return (
+  const renderRecordSelectionArea =
+    recordPreviews.length > 0 ? (
       <RecordSelectionList>
         {recordPreviews.map(({ id, title, imageUrl }) => (
           <RecordSelectionLink key={id} to={id}>
@@ -45,8 +52,14 @@ export function RecordSelection({ recordPreviews }: Props) {
           </RecordSelectionLink>
         ))}
       </RecordSelectionList>
+    ) : (
+      <EmptyIndicator />
     );
-  })();
 
-  return <Root>{renderRecordSelectionArea}</Root>;
+  return (
+    <Root>
+      {renderRecordCount}
+      {renderRecordSelectionArea}
+    </Root>
+  );
 }


### PR DESCRIPTION
# Description

- Added indicator about how many records a `typeId` has. (In other words, record counter)
- Refactored `renderRecordSelectionArea`.
- Changed tests because the UI has been intentionally changed.
