### PR TITLE
chore: add --host to yarn start to test it on real mobile device

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "start": "vite --open",
+    "start": "vite --open --host",
     "lint": "yarn eslint src/**/*.{ts,tsx}",
     "test": "vitest",
     "build": "tsc --noEmit && yarn lint && yarn test --watch=false && vite build",


### PR DESCRIPTION
# Description

- It is known to use `Shift + mouse drag` for pinch in Chromium mobile simulator.
- I tried, but pressing `Shift` always turns the cursor into wierd crossed arrows and I could not pinch anything in Chromium mobile simulator.
- Therefore I decided to use real phone to test mobile touches.
- This will allow mobile devices connected in the same network with the host test the application's mobile interactions, via `http://{host name}:{port number}/`. (`http`, not `https`)
