### PR TITLE
fix: stop empty/error component flashing while switching page

### DIFF
--- a/src/hooks/useShmupArticle.ts
+++ b/src/hooks/useShmupArticle.ts
@@ -9,17 +9,19 @@ export function useShmupArticle(
   currentRecordId?: string
 ) {
   const [recordArticle, setRecordArticle] = useState<ShmupRecord>();
-  const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [isLoading, setIsLoading] = useState<boolean>(true);
   const [isError, setIsError] = useState<boolean>(false);
 
   useEffect(() => {
-    setRecordArticle(undefined);
     if (currentRecordId === undefined) {
+      setRecordArticle(undefined);
       return;
     }
+
     (async () => {
       setIsError(false);
       setIsLoading(true);
+      setRecordArticle(undefined);
       try {
         const response = await axios.get<ShmupRecord>(
           getAPIURL('records', endpointName, currentRecordId)

--- a/src/hooks/useShmupRecordPreviewList.ts
+++ b/src/hooks/useShmupRecordPreviewList.ts
@@ -9,14 +9,14 @@ export function useShmupRecordPreviewList(endpointName: string) {
   const [recordPreviews, setRecordPreviews] = useState<ShmupRecordPreview[]>(
     []
   );
-  const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [isLoading, setIsLoading] = useState<boolean>(true);
   const [isError, setIsError] = useState<boolean>(false);
 
   useEffect(() => {
     (async () => {
-      setRecordPreviews([]);
-      setIsError(false);
       setIsLoading(true);
+      setIsError(false);
+      setRecordPreviews([]);
 
       try {
         const response = await axios.get<string[]>(


### PR DESCRIPTION
# Description

- The error or empty indicator flashes when switching `typeId` or `recordId`.
- It was seen that `useShmupArticle` and `useShmupRecordPreviewList` change the data state that they have before changing loading state (`isLoading`).
- This PR will stop flashing error or empty indicator when switching `typeId` or `recordId`.