### PR TITLE
chore: migrate to aws api

### DIFF
--- a/src/components/atoms/NavigationNode/index.tsx
+++ b/src/components/atoms/NavigationNode/index.tsx
@@ -19,7 +19,7 @@ const Root = styled.div<RootProps>`
     transition: color 100ms linear;
 
     ${({ $url }) =>
-      $url !== undefined
+      $url
         ? `
           &:hover {
             color: var(--hovering-color);
@@ -57,14 +57,13 @@ interface Props {
 
 export function NavigationNode({ depth, nodeInfo }: Props) {
   const text = textsForNavigation[nodeInfo.id] ?? nodeInfo.id;
-  const renderLinkText =
-    nodeInfo.linkTo !== undefined ? (
-      <NoUnderlineLinkOnNotHover to={nodeInfo.linkTo}>
-        {text}
-      </NoUnderlineLinkOnNotHover>
-    ) : (
-      text
-    );
+  const renderLinkText = nodeInfo.linkTo ? (
+    <NoUnderlineLinkOnNotHover to={nodeInfo.linkTo}>
+      {text}
+    </NoUnderlineLinkOnNotHover>
+  ) : (
+    text
+  );
 
   const renderMainBody = (() => {
     switch (depth) {

--- a/src/components/molecules/ArticleExtra/index.tsx
+++ b/src/components/molecules/ArticleExtra/index.tsx
@@ -36,27 +36,26 @@ interface Props {
 }
 
 export function ArticleExtra({ comment, youtubeUrl }: Props) {
-  const renderYoutube =
-    youtubeUrl !== undefined ? (
-      <ListItem>
-        <ListItemWrapper>
-          <ListItemTitle>유튜브 영상</ListItemTitle>
-          <ListItemContent>
-            <iframe
-              width="100%"
-              height="480px"
-              src={youtubeUrl}
-              title="YouTube video player"
-              allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-              allowFullScreen
-              style={{
-                borderWidth: 0,
-              }}
-            />
-          </ListItemContent>
-        </ListItemWrapper>
-      </ListItem>
-    ) : null;
+  const renderYoutube = youtubeUrl ? (
+    <ListItem>
+      <ListItemWrapper>
+        <ListItemTitle>유튜브 영상</ListItemTitle>
+        <ListItemContent>
+          <iframe
+            width="100%"
+            height="480px"
+            src={youtubeUrl}
+            title="YouTube video player"
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+            allowFullScreen
+            style={{
+              borderWidth: 0,
+            }}
+          />
+        </ListItemContent>
+      </ListItemWrapper>
+    </ListItem>
+  ) : null;
 
   return (
     <Root>

--- a/src/components/molecules/ArticleSummary/index.test.tsx
+++ b/src/components/molecules/ArticleSummary/index.test.tsx
@@ -9,15 +9,15 @@ import { convertDateToString } from '^/utils/date-to-string';
 import { ArticleSummary } from '.';
 
 const testDataWithoutSpecialTags: ShmupRecord = {
-  id: '20230514',
+  recordId: '20230514',
   when: new Date('May 14 2023'),
-  subjectId: 'dodonpachi-cshot',
+  typeId: 'dodonpachi-cshot',
   stage: '2-4',
   score: '80000000',
   byWhat: 'Arcade in Akatronics',
   comment: '야스오 2-4 진출',
   thumbnailUrl: 'Thumbnail URL',
-  originalImageUrl: 'Original Image URL',
+  originalImageUrls: ['Original Image URL'],
 };
 
 const testDataWithSpecialTags: ShmupRecord = {
@@ -46,7 +46,7 @@ describe('ArticleSummary', () => {
     render(<RouterProvider router={router} />);
 
     const thumbnail = screen.getByAltText(
-      `${testDataWithoutSpecialTags.subjectId} ${convertDateToString(
+      `${testDataWithoutSpecialTags.typeId} ${convertDateToString(
         testDataWithoutSpecialTags.when
       )} ${testDataWithoutSpecialTags.stage}스테이지 ${
         testDataWithoutSpecialTags.score

--- a/src/components/molecules/ArticleSummary/index.tsx
+++ b/src/components/molecules/ArticleSummary/index.tsx
@@ -140,7 +140,7 @@ export function ArticleSummary({ record }: Props) {
   }
 
   const renderSpecialTags =
-    record.specialTags !== undefined && record.specialTags.length > 0 ? (
+    record.specialTags && record.specialTags.length > 0 ? (
       <li>
         <ListItemTitle>특이사항</ListItemTitle>
         <ListItemContent>

--- a/src/components/molecules/ArticleSummary/index.tsx
+++ b/src/components/molecules/ArticleSummary/index.tsx
@@ -130,7 +130,7 @@ export function ArticleSummary({ record }: Props) {
     const textToUri = encodeURI(
       `${convertDateToString(record.when)}, ${
         textsForArticle[record.byWhat]
-      }에서 플레이한 ${textsForArticle[record.subjectId]}에서, ${
+      }에서 플레이한 ${textsForArticle[record.typeId]}에서, ${
         record.score
       }점으로 ${record.stage} 달성!`
     );
@@ -175,7 +175,7 @@ export function ArticleSummary({ record }: Props) {
 
   const renderImageModal = isImageModalShow ? (
     <ImageDisplayModal
-      imageUrl={record.originalImageUrl}
+      imageUrls={record.originalImageUrls}
       onExit={() => {
         setIsImageModalShow(false);
       }}
@@ -195,7 +195,7 @@ export function ArticleSummary({ record }: Props) {
       <Root>
         <Thumbnail
           imageSrc={record.thumbnailUrl}
-          altText={`${record.subjectId} ${convertDateToString(record.when)} ${
+          altText={`${record.typeId} ${convertDateToString(record.when)} ${
             record.stage
           }스테이지 ${record.score}점`}
           onClick={() => {

--- a/src/components/molecules/ImageDisplayModal/index.test.tsx
+++ b/src/components/molecules/ImageDisplayModal/index.test.tsx
@@ -12,7 +12,7 @@ describe('ImageDisplayModal', () => {
   it('should close modal only on-click close button', () => {
     const mockFn = vi.fn();
     const { container } = render(
-      <ImageDisplayModal imageUrl="" onExit={mockFn} />
+      <ImageDisplayModal imageUrls={['']} onExit={mockFn} />
     );
 
     const clickToCloseIcon = container.querySelector('#Click-to-close-icon');

--- a/src/components/molecules/ImageDisplayModal/index.tsx
+++ b/src/components/molecules/ImageDisplayModal/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import styled from 'styled-components';
 
 import { ImageZoomAndMoveController } from '^/components/molecules/ImageZoomAndMoveController';
@@ -15,14 +15,20 @@ const CloseButtonWrapper = styled.div`
 `;
 
 interface Props {
-  imageUrl: string;
+  imageUrls: string[];
   onExit(): void;
 }
 
-export function ImageDisplayModal({ imageUrl, onExit }: Props) {
+export function ImageDisplayModal({ imageUrls, onExit }: Props) {
+  /**
+   * @todo
+   * Make going to prev/next image
+   */
+  const [index] = useState<number>(0);
+
   return (
     <Overlay>
-      <ImageZoomAndMoveController imageUrl={imageUrl} />
+      <ImageZoomAndMoveController imageUrl={imageUrls[index]} />
       <CloseButtonWrapper>
         <Button
           type={ButtonType.CLEAR}

--- a/src/components/molecules/NavigationTree/index.tsx
+++ b/src/components/molecules/NavigationTree/index.tsx
@@ -15,7 +15,7 @@ interface Props {
 
 export function NavigationTree({ depth, nodeInfo }: Props) {
   const isHavingChildren =
-    nodeInfo.childNavNodes === undefined || nodeInfo.childNavNodes.length === 0;
+    !nodeInfo.childNavNodes || nodeInfo.childNavNodes.length === 0;
 
   const renderSubtrees = !isHavingChildren
     ? nodeInfo.childNavNodes?.map((childNavNode) => (

--- a/src/components/organisms/Article/index.test.tsx
+++ b/src/components/organisms/Article/index.test.tsx
@@ -9,15 +9,15 @@ import { convertDateToString } from '^/utils/date-to-string';
 import { Article } from '.';
 
 const testData: ShmupRecord = {
-  id: '20230514',
+  recordId: '20230514',
   when: new Date('May 14 2023'),
-  subjectId: 'dodonpachi-cshot',
+  typeId: 'dodonpachi-cshot',
   stage: '2-4',
   score: '80000000',
   byWhat: 'Arcade in Akatronics',
   comment: '야스오 2-4 진출',
   thumbnailUrl: 'Thumbnail URL',
-  originalImageUrl: 'Original Image URL',
+  originalImageUrls: ['Original Image URL'],
   specialTags: ['science', 'no miss'],
   youtubeUrl: 'Youtube URL',
 };
@@ -43,7 +43,7 @@ describe('Article', () => {
     render(<RouterProvider router={router} />);
 
     const thumbnail = screen.getByAltText(
-      `${testData.subjectId} ${convertDateToString(testData.when)} ${
+      `${testData.typeId} ${convertDateToString(testData.when)} ${
         testData.stage
       }스테이지 ${testData.score}점`
     );

--- a/src/components/organisms/RecordSelection/__snapshots__/index.test.tsx.snap
+++ b/src/components/organisms/RecordSelection/__snapshots__/index.test.tsx.snap
@@ -170,7 +170,7 @@ exports[`RecordSelection > should match snapshot with non-empty recordIds 1`] = 
         <img
           alt="2023년 10월 28일"
           class="c5"
-          src="2023-10-28.jpg"
+          src="Thumbnail URL"
         />
         <div
           class="c6"
@@ -193,7 +193,7 @@ exports[`RecordSelection > should match snapshot with non-empty recordIds 1`] = 
         <img
           alt="2023년 5월 14일"
           class="c5"
-          src="2023-05-14.jpg"
+          src="Thumbnail URL"
         />
         <div
           class="c6"
@@ -216,7 +216,7 @@ exports[`RecordSelection > should match snapshot with non-empty recordIds 1`] = 
         <img
           alt="2022년 11월 21일"
           class="c5"
-          src="2022-11-21.jpg"
+          src="Thumbnail URL"
         />
         <div
           class="c6"

--- a/src/components/organisms/RecordSelection/index.test.tsx
+++ b/src/components/organisms/RecordSelection/index.test.tsx
@@ -6,17 +6,55 @@ import 'jest-styled-components';
 
 import { ShmupRecordPreview } from '^/types';
 import { RecordSelection } from '.';
-import { convertDateToString } from '^/utils/date-to-string';
 
-const recordIdsForTest: string[] = ['2023-10-28', '2023-05-14', '2022-11-21'];
+// const recordIdsForTest: string[] = ['2023-10-28', '2023-05-14', '2022-11-21'];
 
-const recordPreviewForTest = recordIdsForTest.map(
-  (recordId): ShmupRecordPreview => ({
-    id: recordId,
-    title: convertDateToString(new Date(recordId)),
-    imageUrl: `${recordId}.jpg`,
-  })
-);
+// const recordPreviewForTest = recordIdsForTest.map(
+//   (recordId): ShmupRecordPreview => ({
+//     id: recordId,
+//     title: convertDateToString(new Date(recordId)),
+//     imageUrl: `${recordId}.jpg`,
+//   })
+// );
+
+const recordPreviewForTest: ShmupRecordPreview[] = [
+  {
+    recordId: 'dodonpachi-cshot--2023-10-28',
+    when: new Date('Oct 28 2023'),
+    typeId: 'dodonpachi-cshot',
+    stage: '2-4',
+    score: '80000000',
+    byWhat: 'Arcade in Akatronics',
+    comment: '야스오 2-4 진출',
+    thumbnailUrl: 'Thumbnail URL',
+    originalImageUrls: ['Original Image URL'],
+    title: '2023년 10월 28일',
+  },
+  {
+    recordId: 'dodonpachi-cshot--2023-05-14',
+    when: new Date('May 14 2023'),
+    typeId: 'dodonpachi-cshot',
+    stage: '2-4',
+    score: '80000000',
+    byWhat: 'Arcade in Akatronics',
+    comment: '야스오 2-4 진출',
+    thumbnailUrl: 'Thumbnail URL',
+    originalImageUrls: ['Original Image URL'],
+    title: '2023년 5월 14일',
+  },
+  {
+    recordId: 'dodonpachi-cshot--2022-11-21',
+    when: new Date('Nov 21 2023'),
+    typeId: 'dodonpachi-cshot',
+    stage: '2-4',
+    score: '80000000',
+    byWhat: 'Arcade in Akatronics',
+    comment: '김두한',
+    thumbnailUrl: 'Thumbnail URL',
+    originalImageUrls: ['Original Image URL'],
+    title: '2022년 11월 21일',
+  },
+];
 
 describe('RecordSelection', () => {
   beforeEach(() => {

--- a/src/components/organisms/RecordSelection/index.tsx
+++ b/src/components/organisms/RecordSelection/index.tsx
@@ -46,9 +46,9 @@ export function RecordSelection({ recordPreviews }: Props) {
   const renderRecordSelectionArea =
     recordPreviews.length > 0 ? (
       <RecordSelectionList>
-        {recordPreviews.map(({ id, title, imageUrl }) => (
-          <RecordSelectionLink key={id} to={id}>
-            <RecordListCard imageUrl={imageUrl} title={title} />
+        {recordPreviews.map(({ recordId, title, thumbnailUrl }) => (
+          <RecordSelectionLink key={recordId} to={recordId.split('--')[1]}>
+            <RecordListCard imageUrl={thumbnailUrl} title={title} />
           </RecordSelectionLink>
         ))}
       </RecordSelectionList>

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -2,6 +2,7 @@
 
 interface ImportMetaEnv {
   readonly VITE_API_URL: string;
+  readonly VITE_STATIC_IMAGE_URL: string;
 }
 
 interface ImportMeta {

--- a/src/hooks/useShmupArticle.ts
+++ b/src/hooks/useShmupArticle.ts
@@ -3,6 +3,7 @@ import { useState, useEffect } from 'react';
 
 import { ShmupRecord } from '^/types';
 import { getAPIURL } from '^/utils/api-url';
+import { getStaticImageUrl } from '^/utils/static-image-url';
 
 interface GetShmupRecordArticleResponse {
   attempts: number;
@@ -34,6 +35,10 @@ export function useShmupArticle(
         );
         setRecordArticle({
           ...response.data.data,
+          thumbnailUrl: getStaticImageUrl(response.data.data.thumbnailUrl),
+          originalImageUrls: response.data.data.originalImageUrls.map(
+            (originalImageUrl) => getStaticImageUrl(originalImageUrl)
+          ),
           when: new Date(response.data.data.when),
         });
       } catch (error) {

--- a/src/hooks/useShmupArticle.ts
+++ b/src/hooks/useShmupArticle.ts
@@ -19,7 +19,7 @@ export function useShmupArticle(
   const [isError, setIsError] = useState<boolean>(false);
 
   useEffect(() => {
-    if (currentRecordId === undefined) {
+    if (!currentRecordId) {
       setRecordArticle(undefined);
       return;
     }

--- a/src/hooks/useShmupArticle.ts
+++ b/src/hooks/useShmupArticle.ts
@@ -4,6 +4,12 @@ import { useState, useEffect } from 'react';
 import { ShmupRecord } from '^/types';
 import { getAPIURL } from '^/utils/api-url';
 
+interface GetShmupRecordArticleResponse {
+  attempts: number;
+  statusCode: number;
+  data: ShmupRecord;
+}
+
 export function useShmupArticle(
   endpointName: string,
   currentRecordId?: string
@@ -23,12 +29,12 @@ export function useShmupArticle(
       setIsLoading(true);
       setRecordArticle(undefined);
       try {
-        const response = await axios.get<ShmupRecord>(
+        const response = await axios.get<GetShmupRecordArticleResponse>(
           getAPIURL('records', endpointName, currentRecordId)
         );
         setRecordArticle({
-          ...response.data,
-          when: new Date(response.data.when),
+          ...response.data.data,
+          when: new Date(response.data.data.when),
         });
       } catch (error) {
         if (axios.isAxiosError(error)) {

--- a/src/hooks/useShmupRecordPreviewList.ts
+++ b/src/hooks/useShmupRecordPreviewList.ts
@@ -33,11 +33,15 @@ export function useShmupRecordPreviewList(endpointName: string) {
           .sort((a, b) => b.recordId.localeCompare(a.recordId))
           .map(
             (record): ShmupRecordPreview => ({
-              id: record.recordId.split('--')[1],
+              ...record,
+              thumbnailUrl: getStaticImageUrl(record.thumbnailUrl),
+              originalImageUrls: record.originalImageUrls.map(
+                (originalImageUrl) => getStaticImageUrl(originalImageUrl)
+              ),
+              when: new Date(record.when),
               title: `${convertDateToString(
                 new Date(record.recordId.split('--')[1])
               )} 기록`,
-              imageUrl: getStaticImageUrl(record.recordId, 'thumbnail.jpg'),
             })
           );
         setRecordPreviews(newRecordPreviews);

--- a/src/hooks/useShmupRecordPreviewList.ts
+++ b/src/hooks/useShmupRecordPreviewList.ts
@@ -2,8 +2,15 @@ import axios from 'axios';
 import { useEffect, useState } from 'react';
 
 import { getAPIURL } from '^/utils/api-url';
-import { ShmupRecordPreview } from '^/types';
+import { ShmupRecord, ShmupRecordPreview } from '^/types';
 import { convertDateToString } from '^/utils/date-to-string';
+import { getStaticImageUrl } from '^/utils/static-image-url';
+
+interface GetShmupRecordPreviewListResponse {
+  attempts: number;
+  statusCode: number;
+  data: ShmupRecord[];
+}
 
 export function useShmupRecordPreviewList(endpointName: string) {
   const [recordPreviews, setRecordPreviews] = useState<ShmupRecordPreview[]>(
@@ -19,21 +26,20 @@ export function useShmupRecordPreviewList(endpointName: string) {
       setRecordPreviews([]);
 
       try {
-        const response = await axios.get<string[]>(
-          getAPIURL('records', endpointName, 'selection')
+        const response = await axios.get<GetShmupRecordPreviewListResponse>(
+          getAPIURL('records', endpointName)
         );
-        const newRecordPreviews = response.data.map(
-          (recordId): ShmupRecordPreview => ({
-            id: recordId,
-            title: `${convertDateToString(new Date(recordId))} 기록`,
-            imageUrl: getAPIURL(
-              'records',
-              endpointName,
-              'images',
-              `${recordId}_thumbnail.jpg`
-            ),
-          })
-        );
+        const newRecordPreviews = response.data.data
+          .sort((a, b) => b.recordId.localeCompare(a.recordId))
+          .map(
+            (record): ShmupRecordPreview => ({
+              id: record.recordId.split('--')[1],
+              title: `${convertDateToString(
+                new Date(record.recordId.split('--')[1])
+              )} 기록`,
+              imageUrl: getStaticImageUrl(record.recordId, 'thumbnail.jpg'),
+            })
+          );
         setRecordPreviews(newRecordPreviews);
       } catch (error) {
         if (axios.isAxiosError(error)) {

--- a/src/pages/RecordPage/index.tsx
+++ b/src/pages/RecordPage/index.tsx
@@ -73,7 +73,7 @@ export function RecordPage() {
       );
     }
 
-    if (recordArticle === undefined || isError) {
+    if (!recordArticle || isError) {
       return <ErrorIndicator title="본문을 불러오는 중 오류가 발생했습니다." />;
     }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,12 +4,6 @@ export interface NavNodeInfo {
   childNavNodes?: NavNodeInfo[];
 }
 
-export interface ShmupRecordPreview {
-  id: string;
-  title: string;
-  imageUrl: string;
-}
-
 export interface ShmupRecord {
   recordId: string;
   when: Date;
@@ -26,6 +20,10 @@ export interface ShmupRecord {
   originalImageUrls: string[];
   youtubeUrl?: string;
   specialTags?: string[];
+}
+
+export interface ShmupRecordPreview extends ShmupRecord {
+  title: string;
 }
 
 export interface DescriptionListItem {

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,9 +11,9 @@ export interface ShmupRecordPreview {
 }
 
 export interface ShmupRecord {
-  id: string;
+  recordId: string;
   when: Date;
-  subjectId: string;
+  typeId: string;
   stage: string;
   /**
    * Why score should be string?
@@ -23,7 +23,7 @@ export interface ShmupRecord {
   byWhat: string;
   comment: string;
   thumbnailUrl: string;
-  originalImageUrl: string;
+  originalImageUrls: string[];
   youtubeUrl?: string;
   specialTags?: string[];
 }

--- a/src/utils/static-image-url.ts
+++ b/src/utils/static-image-url.ts
@@ -1,0 +1,3 @@
+export function getStaticImageUrl(...paths: string[]) {
+  return `${import.meta.env.VITE_STATIC_IMAGE_URL}/${paths.join('/')}`;
+}


### PR DESCRIPTION
# Description

- This PR will make the app browse data from AWS API endpoints. In other words, we can manage the app more flexible than before.
- Requires static image url as well, since static images will be still loaded from ReadOnlyAPIEndpoint.
- Requires additional configuration (such as environment variables in Vercel deploys)
