### PR TITLE
refactor: add css vars, simplify component codes, rename to reduce confusion, and add title for akatronics-5th-anniversary

### DIFF
--- a/src/components/atoms/Avatar/__snapshots__/index.test.tsx.snap
+++ b/src/components/atoms/Avatar/__snapshots__/index.test.tsx.snap
@@ -12,7 +12,7 @@ exports[`TitleWithAvatar > should have a snapshot match for its appearance 1`] =
 }
 
 .c1 {
-  color: #000000;
+  color: var(--black-color);
   font-size: 16px;
   font-weight: 500;
   border-radius: inherit;

--- a/src/components/atoms/Avatar/index.tsx
+++ b/src/components/atoms/Avatar/index.tsx
@@ -16,7 +16,7 @@ const Root = styled.div<RootProps>`
 `;
 
 const TmpPlaceholder = styled.img`
-  color: #000000;
+  color: var(--black-color);
 
   font-size: 16px;
   font-weight: 500;

--- a/src/components/atoms/Avatar/index.tsx
+++ b/src/components/atoms/Avatar/index.tsx
@@ -15,7 +15,7 @@ const Root = styled.div<RootProps>`
   background-color: var(--gray-color);
 `;
 
-const TmpPlaceholder = styled.img`
+const Image = styled.img`
   color: var(--black-color);
 
   font-size: 16px;
@@ -34,7 +34,7 @@ interface Props {
 export function Avatar({ pxSize, imageUrl }: Props) {
   return (
     <Root $pxSize={pxSize}>
-      <TmpPlaceholder src={imageUrl} alt="YSOShmupRecords avatar" />
+      <Image src={imageUrl} alt="YSOShmupRecords avatar" />
     </Root>
   );
 }

--- a/src/components/atoms/Button/__snapshots__/index.test.tsx.snap
+++ b/src/components/atoms/Button/__snapshots__/index.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`Sample test > should have a snapshot match for clear button 1`] = `
   font-size: 16px;
   font-weight: 500;
   padding: 8px 16px;
-  color: #ffffff;
+  color: var(--white-color);
   background-color: transparent;
   border: none;
   border-radius: 16px;
@@ -16,7 +16,7 @@ exports[`Sample test > should have a snapshot match for clear button 1`] = `
 
 .c0:hover {
   background-color: var(--hovering-color);
-  color: #ffffff;
+  color: var(--white-color);
 }
 
 .c0:disabled {
@@ -40,7 +40,7 @@ exports[`Sample test > should have a snapshot match for disabled clear button 1`
   font-size: 16px;
   font-weight: 500;
   padding: 8px 16px;
-  color: #ffffff;
+  color: var(--white-color);
   background-color: transparent;
   border: none;
   border-radius: 16px;
@@ -49,7 +49,7 @@ exports[`Sample test > should have a snapshot match for disabled clear button 1`
 
 .c0:hover {
   background-color: var(--hovering-color);
-  color: #ffffff;
+  color: var(--white-color);
 }
 
 .c0:disabled {
@@ -83,12 +83,12 @@ exports[`Sample test > should have a snapshot match for disabled line button 1`]
 
 .c0:hover {
   background-color: var(--hovering-color);
-  color: #ffffff;
+  color: var(--white-color);
 }
 
 .c0:disabled {
   border: none;
-  color: #ffffff;
+  color: var(--white-color);
   background-color: var(--gray-color);
   text-decoration: none;
 }
@@ -117,12 +117,12 @@ exports[`Sample test > should have a snapshot match for disabled round line butt
 
 .c0:hover {
   background-color: var(--hovering-color);
-  color: #ffffff;
+  color: var(--white-color);
 }
 
 .c0:disabled {
   border: none;
-  color: #ffffff;
+  color: var(--white-color);
   background-color: var(--gray-color);
   text-decoration: none;
 }
@@ -142,7 +142,7 @@ exports[`Sample test > should have a snapshot match for disabled round solid but
   font-size: 16px;
   font-weight: 500;
   padding: 8px 16px;
-  color: #ffffff;
+  color: var(--white-color);
   background-color: var(--primary-color);
   border: 1px solid var(--primary-color);
   border-radius: 16px;
@@ -151,12 +151,12 @@ exports[`Sample test > should have a snapshot match for disabled round solid but
 
 .c0:hover {
   background-color: var(--hovering-color);
-  color: #ffffff;
+  color: var(--white-color);
 }
 
 .c0:disabled {
   border: none;
-  color: #ffffff;
+  color: var(--white-color);
   background-color: var(--gray-color);
   text-decoration: none;
 }
@@ -176,7 +176,7 @@ exports[`Sample test > should have a snapshot match for disabled solid button 1`
   font-size: 16px;
   font-weight: 500;
   padding: 8px 16px;
-  color: #ffffff;
+  color: var(--white-color);
   background-color: var(--primary-color);
   border: 1px solid var(--primary-color);
   border-radius: 4px;
@@ -185,12 +185,12 @@ exports[`Sample test > should have a snapshot match for disabled solid button 1`
 
 .c0:hover {
   background-color: var(--hovering-color);
-  color: #ffffff;
+  color: var(--white-color);
 }
 
 .c0:disabled {
   border: none;
-  color: #ffffff;
+  color: var(--white-color);
   background-color: var(--gray-color);
   text-decoration: none;
 }
@@ -219,12 +219,12 @@ exports[`Sample test > should have a snapshot match for line button 1`] = `
 
 .c0:hover {
   background-color: var(--hovering-color);
-  color: #ffffff;
+  color: var(--white-color);
 }
 
 .c0:disabled {
   border: none;
-  color: #ffffff;
+  color: var(--white-color);
   background-color: var(--gray-color);
   text-decoration: none;
 }
@@ -252,12 +252,12 @@ exports[`Sample test > should have a snapshot match for round line button 1`] = 
 
 .c0:hover {
   background-color: var(--hovering-color);
-  color: #ffffff;
+  color: var(--white-color);
 }
 
 .c0:disabled {
   border: none;
-  color: #ffffff;
+  color: var(--white-color);
   background-color: var(--gray-color);
   text-decoration: none;
 }
@@ -276,7 +276,7 @@ exports[`Sample test > should have a snapshot match for round solid button 1`] =
   font-size: 16px;
   font-weight: 500;
   padding: 8px 16px;
-  color: #ffffff;
+  color: var(--white-color);
   background-color: var(--primary-color);
   border: 1px solid var(--primary-color);
   border-radius: 16px;
@@ -285,12 +285,12 @@ exports[`Sample test > should have a snapshot match for round solid button 1`] =
 
 .c0:hover {
   background-color: var(--hovering-color);
-  color: #ffffff;
+  color: var(--white-color);
 }
 
 .c0:disabled {
   border: none;
-  color: #ffffff;
+  color: var(--white-color);
   background-color: var(--gray-color);
   text-decoration: none;
 }
@@ -309,7 +309,7 @@ exports[`Sample test > should have a snapshot match for solid button 1`] = `
   font-size: 16px;
   font-weight: 500;
   padding: 8px 16px;
-  color: #ffffff;
+  color: var(--white-color);
   background-color: var(--primary-color);
   border: 1px solid var(--primary-color);
   border-radius: 4px;
@@ -318,12 +318,12 @@ exports[`Sample test > should have a snapshot match for solid button 1`] = `
 
 .c0:hover {
   background-color: var(--hovering-color);
-  color: #ffffff;
+  color: var(--white-color);
 }
 
 .c0:disabled {
   border: none;
-  color: #ffffff;
+  color: var(--white-color);
   background-color: var(--gray-color);
   text-decoration: none;
 }

--- a/src/components/atoms/Button/index.tsx
+++ b/src/components/atoms/Button/index.tsx
@@ -12,11 +12,11 @@ const backgroundColorByType: Record<ButtonType, string> = {
 };
 
 const colorByType: Record<ButtonType, string> = {
-  [ButtonType.SOLID]: '#ffffff',
+  [ButtonType.SOLID]: 'var(--white-color)',
   [ButtonType.LINE]: 'var(--primary-color)',
-  [ButtonType.ROUND_SOLID]: '#ffffff',
+  [ButtonType.ROUND_SOLID]: 'var(--white-color)',
   [ButtonType.ROUND_LINE]: 'var(--primary-color)',
-  [ButtonType.CLEAR]: '#ffffff',
+  [ButtonType.CLEAR]: 'var(--white-color)',
 };
 
 const borderByType: Record<ButtonType, string> = {
@@ -36,10 +36,10 @@ const borderRadiusByType: Record<ButtonType, string> = {
 };
 
 const disabledColorByType: Record<ButtonType, string> = {
-  [ButtonType.SOLID]: '#ffffff',
-  [ButtonType.LINE]: '#ffffff',
-  [ButtonType.ROUND_SOLID]: '#ffffff',
-  [ButtonType.ROUND_LINE]: '#ffffff',
+  [ButtonType.SOLID]: 'var(--white-color)',
+  [ButtonType.LINE]: 'var(--white-color)',
+  [ButtonType.ROUND_SOLID]: 'var(--white-color)',
+  [ButtonType.ROUND_LINE]: 'var(--white-color)',
   [ButtonType.CLEAR]: 'var(--gray-color)',
 };
 
@@ -81,7 +81,7 @@ const Root = styled.button<RootProps>`
 
   &:hover {
     background-color: var(--hovering-color);
-    color: #ffffff;
+    color: var(--white-color);
   }
 
   &:disabled {

--- a/src/components/atoms/MenuOpenCloseIcon/__snapshots__/index.test.tsx.snap
+++ b/src/components/atoms/MenuOpenCloseIcon/__snapshots__/index.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`MenuOpenCloseIcon > should be a cross icon when open 1`] = `
 .c1 {
   width: 24px;
   height: 2px;
-  background-color: #ffffff;
+  background-color: var(--white-color);
   transition-property: left,top,transform;
   transition-duration: 500ms;
   transition-timing-function: ease-in-out;
@@ -17,7 +17,7 @@ exports[`MenuOpenCloseIcon > should be a cross icon when open 1`] = `
 .c2 {
   width: 24px;
   height: 2px;
-  background-color: #ffffff;
+  background-color: var(--white-color);
   transition-property: left,top,transform;
   transition-duration: 500ms;
   transition-timing-function: ease-in-out;
@@ -30,7 +30,7 @@ exports[`MenuOpenCloseIcon > should be a cross icon when open 1`] = `
 .c3 {
   width: 24px;
   height: 2px;
-  background-color: #ffffff;
+  background-color: var(--white-color);
   transition-property: left,top,transform;
   transition-duration: 500ms;
   transition-timing-function: ease-in-out;
@@ -66,7 +66,7 @@ exports[`MenuOpenCloseIcon > should be a stack icon when closed 1`] = `
 .c1 {
   width: 24px;
   height: 2px;
-  background-color: #ffffff;
+  background-color: var(--white-color);
   transition-property: left,top,transform;
   transition-duration: 500ms;
   transition-timing-function: ease-in-out;
@@ -79,7 +79,7 @@ exports[`MenuOpenCloseIcon > should be a stack icon when closed 1`] = `
 .c2 {
   width: 24px;
   height: 2px;
-  background-color: #ffffff;
+  background-color: var(--white-color);
   transition-property: left,top,transform;
   transition-duration: 500ms;
   transition-timing-function: ease-in-out;
@@ -92,7 +92,7 @@ exports[`MenuOpenCloseIcon > should be a stack icon when closed 1`] = `
 .c3 {
   width: 24px;
   height: 2px;
-  background-color: #ffffff;
+  background-color: var(--white-color);
   transition-property: left,top,transform;
   transition-duration: 500ms;
   transition-timing-function: ease-in-out;

--- a/src/components/atoms/MenuOpenCloseIcon/index.tsx
+++ b/src/components/atoms/MenuOpenCloseIcon/index.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components';
 const commonStickStyle = `
   width: 24px;
   height: 2px;
-  background-color: #ffffff;
+  background-color: var(--white-color);
 
   transition-property: left, top, transform;
   transition-duration: 500ms;

--- a/src/components/atoms/NavigationNode/index.tsx
+++ b/src/components/atoms/NavigationNode/index.tsx
@@ -11,7 +11,7 @@ interface RootProps {
 
 const Root = styled.div<RootProps>`
   & > * {
-    color: #ffffff;
+    color: var(--white-color);
 
     font-style: normal;
     line-height: normal;

--- a/src/components/atoms/SpecialTag/__snapshots__/index.test.tsx.snap
+++ b/src/components/atoms/SpecialTag/__snapshots__/index.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`SpecialTag > should have a snapshot match 1`] = `
   border-radius: 4px;
   font-size: 12px;
   font-weight: 400;
-  color: #ffffff;
+  color: var(--white-color);
 }
 
 <span

--- a/src/components/atoms/SpecialTag/index.tsx
+++ b/src/components/atoms/SpecialTag/index.tsx
@@ -11,7 +11,7 @@ const Root = styled.span`
 
   font-size: 12px;
   font-weight: 400;
-  color: #ffffff;
+  color: var(--white-color);
 `;
 
 interface Props {

--- a/src/components/molecules/ArticleSummary/index.tsx
+++ b/src/components/molecules/ArticleSummary/index.tsx
@@ -81,7 +81,7 @@ const CopyToClipboardTooltip = styled.div<CopyToClipboardTooltipProps>`
     border-radius: 8px;
 
     background-color: var(--primary-color);
-    color: #ffffff;
+    color: var(--white-color);
 
     display: none;
     justify-content: center;

--- a/src/components/molecules/EmptyIndicator/__snapshots__/index.test.tsx.snap
+++ b/src/components/molecules/EmptyIndicator/__snapshots__/index.test.tsx.snap
@@ -15,12 +15,12 @@ exports[`EmptyIndicator > should have a snapshot match for its appearance 1`] = 
     현재 등록된 기록이 없습니다.
   </h2>
   <button
-    class="sc-bcPKhP EfXTN"
+    class="sc-bcPKhP hULXZF"
   >
     타이틀 화면으로 돌아가기
   </button>
   <button
-    class="sc-bcPKhP EfXTN"
+    class="sc-bcPKhP hULXZF"
   >
     소통창구 (카카오 오픈채팅방)
   </button>

--- a/src/components/molecules/ErrorIndicator/__snapshots__/index.test.tsx.snap
+++ b/src/components/molecules/ErrorIndicator/__snapshots__/index.test.tsx.snap
@@ -30,12 +30,12 @@ exports[`ErrorIndicator > should have a snapshot match for its appearance 1`] = 
     문제 발생 시 아래 카카오 오픈채팅방 버튼으로 문의해주세요.
   </span>
   <button
-    class="sc-bcPKhP EfXTN"
+    class="sc-bcPKhP hULXZF"
   >
     타이틀 화면으로 돌아가기
   </button>
   <button
-    class="sc-bcPKhP EfXTN"
+    class="sc-bcPKhP hULXZF"
   >
     소통창구 (카카오 오픈채팅방)
   </button>

--- a/src/components/molecules/NavigationForest/index.tsx
+++ b/src/components/molecules/NavigationForest/index.tsx
@@ -22,7 +22,7 @@ const TreeContainer = styled.div`
   width: 300px;
   height: 100%;
 
-  border-right: 1px solid #ffffff;
+  border-right: 1px solid var(--white-color);
 
   padding-left: 16px;
   padding-right: 16px;

--- a/src/components/molecules/NavigationTree/index.tsx
+++ b/src/components/molecules/NavigationTree/index.tsx
@@ -14,18 +14,16 @@ interface Props {
 }
 
 export function NavigationTree({ depth, nodeInfo }: Props) {
-  const isHavingChildren =
-    !nodeInfo.childNavNodes || nodeInfo.childNavNodes.length === 0;
-
-  const renderSubtrees = !isHavingChildren
-    ? nodeInfo.childNavNodes?.map((childNavNode) => (
-        <NavigationTree
-          key={childNavNode.id}
-          depth={depth + 1}
-          nodeInfo={childNavNode}
-        />
-      ))
-    : null;
+  const renderSubtrees =
+    nodeInfo.childNavNodes && nodeInfo.childNavNodes.length > 0
+      ? nodeInfo.childNavNodes.map((childNavNode) => (
+          <NavigationTree
+            key={childNavNode.id}
+            depth={depth + 1}
+            nodeInfo={childNavNode}
+          />
+        ))
+      : null;
 
   return (
     <>

--- a/src/components/molecules/RecordListCard/__snapshots__/index.test.tsx.snap
+++ b/src/components/molecules/RecordListCard/__snapshots__/index.test.tsx.snap
@@ -34,13 +34,13 @@ exports[`RecordListCard > should have a snapshot match for its appearance 1`] = 
 }
 
 .c3 {
-  color: #ffffff;
+  color: var(--white-color);
   font-size: 16px;
   font-weight: 600;
 }
 
 .c4 {
-  color: #ffffff;
+  color: var(--white-color);
   font-size: 16px;
   font-weight: 400;
 }
@@ -79,7 +79,7 @@ exports[`RecordListCard > should have a snapshot match showing youtube mark and 
   border-radius: 4px;
   font-size: 12px;
   font-weight: 400;
-  color: #ffffff;
+  color: var(--white-color);
 }
 
 .c0 {
@@ -115,13 +115,13 @@ exports[`RecordListCard > should have a snapshot match showing youtube mark and 
 }
 
 .c3 {
-  color: #ffffff;
+  color: var(--white-color);
   font-size: 16px;
   font-weight: 600;
 }
 
 .c4 {
-  color: #ffffff;
+  color: var(--white-color);
   font-size: 16px;
   font-weight: 400;
 }

--- a/src/components/molecules/RecordListCard/index.test.tsx
+++ b/src/components/molecules/RecordListCard/index.test.tsx
@@ -3,8 +3,22 @@ import { cleanup, render, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it } from 'vitest';
 import 'jest-styled-components';
 
+import { ShmupRecordPreview } from '^/types';
 import AvatarJpgUrl from '^/assets/avatar/avatar.jpeg';
 import { RecordListCard } from '.';
+
+const previewForTest: ShmupRecordPreview = {
+  title: 'kuman514',
+  recordId: 'test-test',
+  when: new Date('2024-01-01'),
+  typeId: 'test',
+  stage: '2-5',
+  score: '12345679',
+  byWhat: 'test',
+  comment: 'test',
+  thumbnailUrl: AvatarJpgUrl,
+  originalImageUrls: [],
+};
 
 describe('RecordListCard', () => {
   beforeEach(() => {
@@ -13,11 +27,7 @@ describe('RecordListCard', () => {
 
   it('should have a snapshot match for its appearance', () => {
     const { container } = render(
-      <RecordListCard
-        imageUrl={AvatarJpgUrl}
-        title="kuman514"
-        stageAndScore="2-5 / 12345679점"
-      />
+      <RecordListCard recordPreview={previewForTest} />
     );
     expect(container.firstChild).toMatchSnapshot();
     expect(screen.getByText(/kuman514/i)).not.toBeNull();
@@ -26,11 +36,11 @@ describe('RecordListCard', () => {
   it('should have a snapshot match showing youtube mark and special tags', () => {
     const { container } = render(
       <RecordListCard
-        imageUrl={AvatarJpgUrl}
-        title="kuman514"
-        stageAndScore="2-5 / 12345679점"
-        youtubeUrl="youtubeurl"
-        specialTags={['yasuo', 'koishi', 'no-miss-all']}
+        recordPreview={{
+          ...previewForTest,
+          youtubeUrl: 'youtube url',
+          specialTags: ['yasuo', 'koishi', 'no-miss-all'],
+        }}
       />
     );
     expect(container.firstChild).toMatchSnapshot();

--- a/src/components/molecules/RecordListCard/index.tsx
+++ b/src/components/molecules/RecordListCard/index.tsx
@@ -45,14 +45,14 @@ const Summary = styled.div`
 `;
 
 const Title = styled.span`
-  color: #ffffff;
+  color: var(--white-color);
 
   font-size: 16px;
   font-weight: 600;
 `;
 
 const StageAndScore = styled.span`
-  color: #ffffff;
+  color: var(--white-color);
 
   font-size: 16px;
   font-weight: 400;

--- a/src/components/molecules/RecordListCard/index.tsx
+++ b/src/components/molecules/RecordListCard/index.tsx
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 import { SpecialTag } from '^/components/atoms/SpecialTag';
 import { textsForArticle } from '^/constants/texts';
 import { ReactComponent as RawYoutubeMarkSvg } from '^/assets/icons/youtube-mark.svg';
+import { ShmupRecordPreview } from '^/types';
 
 const Root = styled.div`
   position: relative;
@@ -72,24 +73,14 @@ const YoutubeMarkSvg = styled(RawYoutubeMarkSvg)`
 `;
 
 interface Props {
-  imageUrl: string;
-  title: string;
-  stageAndScore: string;
-  youtubeUrl?: string;
-  specialTags?: string[];
+  recordPreview: ShmupRecordPreview;
 }
 
-export function RecordListCard({
-  imageUrl,
-  title,
-  stageAndScore,
-  youtubeUrl,
-  specialTags,
-}: Props) {
+export function RecordListCard({ recordPreview }: Props) {
   const renderSpecialTags =
-    specialTags && specialTags.length > 0 ? (
+    recordPreview.specialTags && recordPreview.specialTags.length > 0 ? (
       <SpecialTagsArea>
-        {specialTags.map((specialTag) => (
+        {recordPreview.specialTags.map((specialTag) => (
           <SpecialTag key={`special-tag-${specialTag}`}>
             {textsForArticle[specialTag] ?? specialTag}
           </SpecialTag>
@@ -97,14 +88,16 @@ export function RecordListCard({
       </SpecialTagsArea>
     ) : null;
 
-  const renderYoutubeMarkSvg = youtubeUrl ? <YoutubeMarkSvg /> : null;
+  const renderYoutubeMarkSvg = recordPreview.youtubeUrl ? (
+    <YoutubeMarkSvg />
+  ) : null;
 
   return (
     <Root>
-      <Image src={imageUrl} alt={title} />
+      <Image src={recordPreview.thumbnailUrl} alt={recordPreview.title} />
       <Summary>
-        <Title>{title}</Title>
-        <StageAndScore>{stageAndScore}</StageAndScore>
+        <Title>{recordPreview.title}</Title>
+        <StageAndScore>{`${recordPreview.stage} / ${recordPreview.score}점`}</StageAndScore>
         {renderSpecialTags}
       </Summary>
       {renderYoutubeMarkSvg}

--- a/src/components/molecules/SidebarFooter/__snapshots__/index.test.tsx.snap
+++ b/src/components/molecules/SidebarFooter/__snapshots__/index.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`SidebarFooter > should have a snapshot match for its appearance 1`] = `
   font-size: 16px;
   font-weight: 500;
   padding: 8px 16px;
-  color: #ffffff;
+  color: var(--white-color);
   background-color: transparent;
   border: none;
   border-radius: 16px;
@@ -16,7 +16,7 @@ exports[`SidebarFooter > should have a snapshot match for its appearance 1`] = `
 
 .c3:hover {
   background-color: var(--hovering-color);
-  color: #ffffff;
+  color: var(--white-color);
 }
 
 .c3:disabled {
@@ -35,7 +35,7 @@ exports[`SidebarFooter > should have a snapshot match for its appearance 1`] = `
   row-gap: 8px;
   column-gap: 20px;
   padding: 16px 16px 16px 32px;
-  color: #ffffff;
+  color: var(--white-color);
   font-size: 16px;
   font-weight: 300;
 }
@@ -50,7 +50,7 @@ exports[`SidebarFooter > should have a snapshot match for its appearance 1`] = `
 }
 
 .c2:not(:last-of-type) {
-  border-right: 1px solid #ffffff;
+  border-right: 1px solid var(--white-color);
 }
 
 <div

--- a/src/components/molecules/SidebarFooter/index.tsx
+++ b/src/components/molecules/SidebarFooter/index.tsx
@@ -15,7 +15,7 @@ const Root = styled.div`
   column-gap: 20px;
   padding: 16px 16px 16px 32px;
 
-  color: #ffffff;
+  color: var(--white-color);
 
   font-size: 16px;
   font-weight: 300;
@@ -30,7 +30,7 @@ const ContactButtonWrapper = styled.div`
   padding: 0 10px;
 
   &:not(:last-of-type) {
-    border-right: 1px solid #ffffff;
+    border-right: 1px solid var(--white-color);
   }
 `;
 

--- a/src/components/molecules/TitleWithAvatar/__snapshots__/index.test.tsx.snap
+++ b/src/components/molecules/TitleWithAvatar/__snapshots__/index.test.tsx.snap
@@ -12,7 +12,7 @@ exports[`TitleWithAvatar > should have a snapshot match for its appearance 1`] =
 }
 
 .c3 {
-  color: #000000;
+  color: var(--black-color);
   font-size: 16px;
   font-weight: 500;
   border-radius: inherit;
@@ -31,11 +31,11 @@ exports[`TitleWithAvatar > should have a snapshot match for its appearance 1`] =
 
 .c1 {
   width: 30px;
-  border-top: 1px solid #ffffff;
+  border-top: 1px solid var(--white-color);
 }
 
 .c4 {
-  color: #ffffff;
+  color: var(--white-color);
   font-size: 36px;
   font-weight: 200;
 }

--- a/src/components/molecules/TitleWithAvatar/index.tsx
+++ b/src/components/molecules/TitleWithAvatar/index.tsx
@@ -15,11 +15,11 @@ const Root = styled.div`
 
 const Line = styled.div`
   width: 30px;
-  border-top: 1px solid #ffffff;
+  border-top: 1px solid var(--white-color);
 `;
 
 const Title = styled.h1`
-  color: #ffffff;
+  color: var(--white-color);
 
   font-size: 36px;
   font-weight: 200;

--- a/src/components/organisms/RecordSelection/__snapshots__/index.test.tsx.snap
+++ b/src/components/organisms/RecordSelection/__snapshots__/index.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`RecordSelection > should match snapshot with empty recordIds 1`] = `
   font-size: 16px;
   font-weight: 500;
   padding: 8px 16px;
-  color: #ffffff;
+  color: var(--white-color);
   background-color: var(--primary-color);
   border: 1px solid var(--primary-color);
   border-radius: 4px;
@@ -16,12 +16,12 @@ exports[`RecordSelection > should match snapshot with empty recordIds 1`] = `
 
 .c4:hover {
   background-color: var(--hovering-color);
-  color: #ffffff;
+  color: var(--white-color);
 }
 
 .c4:disabled {
   border: none;
-  color: #ffffff;
+  color: var(--white-color);
   background-color: var(--gray-color);
   text-decoration: none;
 }
@@ -116,13 +116,13 @@ exports[`RecordSelection > should match snapshot with non-empty recordIds 1`] = 
 }
 
 .c7 {
-  color: #ffffff;
+  color: var(--white-color);
   font-size: 16px;
   font-weight: 600;
 }
 
 .c8 {
-  color: #ffffff;
+  color: var(--white-color);
   font-size: 16px;
   font-weight: 400;
 }

--- a/src/components/organisms/RecordSelection/index.tsx
+++ b/src/components/organisms/RecordSelection/index.tsx
@@ -46,27 +46,14 @@ export function RecordSelection({ recordPreviews }: Props) {
   const renderRecordSelectionArea =
     recordPreviews.length > 0 ? (
       <RecordSelectionList>
-        {recordPreviews.map(
-          ({
-            recordId,
-            title,
-            thumbnailUrl,
-            stage,
-            score,
-            specialTags,
-            youtubeUrl,
-          }) => (
-            <RecordSelectionLink key={recordId} to={recordId.split('--')[1]}>
-              <RecordListCard
-                imageUrl={thumbnailUrl}
-                title={title}
-                stageAndScore={`${stage} / ${score}점`}
-                specialTags={specialTags}
-                youtubeUrl={youtubeUrl}
-              />
-            </RecordSelectionLink>
-          )
-        )}
+        {recordPreviews.map((recordPreview) => (
+          <RecordSelectionLink
+            key={recordPreview.recordId}
+            to={recordPreview.recordId.split('--')[1]}
+          >
+            <RecordListCard recordPreview={recordPreview} />
+          </RecordSelectionLink>
+        ))}
       </RecordSelectionList>
     ) : (
       <EmptyIndicator />

--- a/src/components/organisms/RecordSelection/index.tsx
+++ b/src/components/organisms/RecordSelection/index.tsx
@@ -38,26 +38,26 @@ interface Props {
 }
 
 export function RecordSelection({ recordPreviews }: Props) {
-  const renderRecordCount =
-    recordPreviews.length > 0 ? (
-      <RecordCount>총 {recordPreviews.length}건의 기록이 있습니다.</RecordCount>
-    ) : null;
+  const isHavingRecordPreviews = recordPreviews.length > 0;
 
-  const renderRecordSelectionArea =
-    recordPreviews.length > 0 ? (
-      <RecordSelectionList>
-        {recordPreviews.map((recordPreview) => (
-          <RecordSelectionLink
-            key={recordPreview.recordId}
-            to={recordPreview.recordId.split('--')[1]}
-          >
-            <RecordListCard recordPreview={recordPreview} />
-          </RecordSelectionLink>
-        ))}
-      </RecordSelectionList>
-    ) : (
-      <EmptyIndicator />
-    );
+  const renderRecordCount = isHavingRecordPreviews ? (
+    <RecordCount>총 {recordPreviews.length}건의 기록이 있습니다.</RecordCount>
+  ) : null;
+
+  const renderRecordSelectionArea = isHavingRecordPreviews ? (
+    <RecordSelectionList>
+      {recordPreviews.map((recordPreview) => (
+        <RecordSelectionLink
+          key={recordPreview.recordId}
+          to={recordPreview.recordId.split('--')[1]}
+        >
+          <RecordListCard recordPreview={recordPreview} />
+        </RecordSelectionLink>
+      ))}
+    </RecordSelectionList>
+  ) : (
+    <EmptyIndicator />
+  );
 
   return (
     <Root>

--- a/src/constants/texts.ts
+++ b/src/constants/texts.ts
@@ -91,6 +91,7 @@ export const textsForArticle: Record<string, string> = {
   'new-stage-record': '최대 스테이지 갱신',
   'world-record': '전국 TOP',
   'shop-record': '점포 TOP',
+  'akatronics-5th-anniversary': '아카트로닉스 5주년 행사',
 };
 
 export const monthTitle = [

--- a/src/global.css
+++ b/src/global.css
@@ -8,7 +8,6 @@
 :root {
   --primary-color: #22b14c;
   --hovering-color: #39fd72;
-  --gray-color: #b1b1b1;
   --light-background-color: #ffffff;
   --light-font-color: #000000;
   --dark-background-color: #033205;
@@ -16,4 +15,8 @@
   --player1-color: #ff6b00;
   --player2-color: #4073f4;
   --error-color: #ee4444;
+
+  --white-color: #ffffff;
+  --gray-color: #b1b1b1;
+  --black-color: #000000;
 }

--- a/src/hooks/useShmupArticle.ts
+++ b/src/hooks/useShmupArticle.ts
@@ -11,16 +11,13 @@ interface GetShmupRecordArticleResponse {
   data: ShmupRecord;
 }
 
-export function useShmupArticle(
-  endpointName: string,
-  currentRecordId?: string
-) {
+export function useShmupArticle(typeId: string, recordDateId: string) {
   const [recordArticle, setRecordArticle] = useState<ShmupRecord>();
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const [isError, setIsError] = useState<boolean>(false);
 
   useEffect(() => {
-    if (!currentRecordId) {
+    if (!recordDateId) {
       setRecordArticle(undefined);
       return;
     }
@@ -31,7 +28,7 @@ export function useShmupArticle(
       setRecordArticle(undefined);
       try {
         const response = await axios.get<GetShmupRecordArticleResponse>(
-          getAPIURL('records', endpointName, currentRecordId)
+          getAPIURL('records', typeId, recordDateId)
         );
         setRecordArticle({
           ...response.data.data,
@@ -49,7 +46,7 @@ export function useShmupArticle(
       }
       setIsLoading(false);
     })();
-  }, [endpointName, currentRecordId]);
+  }, [typeId, recordDateId]);
 
   return {
     recordArticle,

--- a/src/hooks/useShmupRecordPreviewList.ts
+++ b/src/hooks/useShmupRecordPreviewList.ts
@@ -12,7 +12,7 @@ interface GetShmupRecordPreviewListResponse {
   data: ShmupRecord[];
 }
 
-export function useShmupRecordPreviewList(endpointName: string) {
+export function useShmupRecordPreviewList(typeId: string) {
   const [recordPreviews, setRecordPreviews] = useState<ShmupRecordPreview[]>(
     []
   );
@@ -27,7 +27,7 @@ export function useShmupRecordPreviewList(endpointName: string) {
 
       try {
         const response = await axios.get<GetShmupRecordPreviewListResponse>(
-          getAPIURL('records', endpointName)
+          getAPIURL('records', typeId)
         );
         const newRecordPreviews = response.data.data
           .sort((a, b) => b.recordId.localeCompare(a.recordId))
@@ -54,7 +54,7 @@ export function useShmupRecordPreviewList(endpointName: string) {
 
       setIsLoading(false);
     })();
-  }, [endpointName]);
+  }, [typeId]);
 
   return {
     recordPreviews,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -45,7 +45,7 @@ const router = createBrowserRouter([
                 element: <RecordListPage />,
               },
               {
-                path: ':currentRecordId',
+                path: ':recordDateId',
                 element: <RecordPage />,
               },
             ],

--- a/src/pages/RecordPage/index.tsx
+++ b/src/pages/RecordPage/index.tsx
@@ -45,14 +45,14 @@ const ArticleSkeletonArea = styled.div`
 `;
 
 export function RecordPage() {
-  const { typeId, currentRecordId } = useParams();
+  const { typeId, recordDateId } = useParams();
 
-  if (!typeId || !currentRecordId) {
+  if (!typeId || !recordDateId) {
     return null;
   }
   const { recordArticle, isLoading, isError } = useShmupArticle(
     typeId,
-    currentRecordId
+    recordDateId
   );
 
   const renderMainPart = (() => {
@@ -83,7 +83,7 @@ export function RecordPage() {
   return (
     <Root>
       <TitleArea>
-        <Title>{convertDateToString(new Date(currentRecordId))}</Title>
+        <Title>{convertDateToString(new Date(recordDateId))}</Title>
         <NavRouteTitle />
       </TitleArea>
       {renderMainPart}


### PR DESCRIPTION
# Description

- Used CSS variable for font colors, instead of separate code value.
- Added title for `akatronics-5th-anniversary`.
- Simplified `NavigationTree`'s rendering subtrees by removing only-once-used local condition boolean `isHavingChildren`.
- Unified separate prop members in `RecordListCard` into `ShmupRecordPreview`.
- Corrected wrong name `TmpPlaceholder` -> `Image` in `Avatar`.
- Renamed `currentRecordId` into `recordDateId` in routing & hooks to reduce confusion, since it was named `currentRecordId` but used for identified date of a record.
- Renamed `endpointName` into `typeId` in hooks to reduce confusion, since it was used to browse records about the type passed through the parameter.

(I am looking for something more to refactor. If no more found, I will merge this PR tomorrow.)
