### PR TITLE
fix!: use absolute static image urls instead of relative ones

### DIFF
--- a/src/hooks/useShmupArticle.ts
+++ b/src/hooks/useShmupArticle.ts
@@ -3,7 +3,6 @@ import { useState, useEffect } from 'react';
 
 import { ShmupRecord } from '^/types';
 import { getAPIURL } from '^/utils/api-url';
-import { getStaticImageUrl } from '^/utils/static-image-url';
 
 interface GetShmupRecordArticleResponse {
   attempts: number;
@@ -32,10 +31,6 @@ export function useShmupArticle(typeId: string, recordDateId: string) {
         );
         setRecordArticle({
           ...response.data.data,
-          thumbnailUrl: getStaticImageUrl(response.data.data.thumbnailUrl),
-          originalImageUrls: response.data.data.originalImageUrls.map(
-            (originalImageUrl) => getStaticImageUrl(originalImageUrl)
-          ),
           when: new Date(response.data.data.when),
         });
       } catch (error) {

--- a/src/hooks/useShmupRecordPreviewList.ts
+++ b/src/hooks/useShmupRecordPreviewList.ts
@@ -4,7 +4,6 @@ import { useEffect, useState } from 'react';
 import { getAPIURL } from '^/utils/api-url';
 import { ShmupRecord, ShmupRecordPreview } from '^/types';
 import { convertDateToString } from '^/utils/date-to-string';
-import { getStaticImageUrl } from '^/utils/static-image-url';
 
 interface GetShmupRecordPreviewListResponse {
   attempts: number;
@@ -34,10 +33,6 @@ export function useShmupRecordPreviewList(typeId: string) {
           .map(
             (record): ShmupRecordPreview => ({
               ...record,
-              thumbnailUrl: getStaticImageUrl(record.thumbnailUrl),
-              originalImageUrls: record.originalImageUrls.map(
-                (originalImageUrl) => getStaticImageUrl(originalImageUrl)
-              ),
               when: new Date(record.when),
               title: `${convertDateToString(
                 new Date(record.recordId.split('--')[1])

--- a/src/utils/static-image-url.ts
+++ b/src/utils/static-image-url.ts
@@ -1,3 +1,0 @@
-export function getStaticImageUrl(...paths: string[]) {
-  return `${import.meta.env.VITE_STATIC_IMAGE_URL}/${paths.join('/')}`;
-}


### PR DESCRIPTION
# Description

- Changed shmup records' image URLs, from ones based on the static image base URL saved as an environment variable, into ones just from the recieved record data. (Images temporarily cannot be shown.)