### PR TITLE
fix: correct title's wrong color on dark mode

### DIFF
--- a/src/components/molecules/DescriptionTemplate/index.tsx
+++ b/src/components/molecules/DescriptionTemplate/index.tsx
@@ -12,8 +12,6 @@ const Root = styled.div`
 `;
 
 const Title = styled.h1`
-  color: var(--light-font-color);
-
   font-size: 36px;
   font-weight: 700;
 `;


### PR DESCRIPTION
# Description

- Corrected title's wrong font color on dark mode.
