### PR TITLE
refactor: remove default react imports & rearrange components' imports

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -4,8 +4,7 @@ module.exports = {
     browser: true,
     es2021: true,
   },
-  extends: [
-  ],
+  extends: [],
   parser: '@typescript-eslint/parser',
   parserOptions: {
     ecmaFeatures: {
@@ -14,18 +13,12 @@ module.exports = {
     ecmaVersion: 'latest',
     sourceType: 'module',
   },
-  plugins: [
-    'react',
-    '@typescript-eslint',
-  ],
+  plugins: ['react', '@typescript-eslint'],
   overrides: [
     {
       files: '**/*.+(ts|tsx)',
       parser: '@typescript-eslint/parser',
-      plugins: [
-        'react',
-        '@typescript-eslint',
-      ],
+      plugins: ['react', '@typescript-eslint'],
       extends: [
         'plugin:@typescript-eslint/recommended',
         'plugin:react/recommended',
@@ -33,103 +26,53 @@ module.exports = {
         'prettier',
       ],
       rules: {
-        radix: [
-          'off',
-        ],
-        indent: [
-          'off',
-        ],
-        quotes: [
-          'error',
-          'single',
-        ],
-        semi: [
-          'error',
-          'always',
-        ],
-        'react/function-component-definition': [
-          'off',
-        ],
-        'react/jsx-filename-extension': [
-          'off',
-        ],
-        'linebreak-style': [
-          'off',
-        ],
-        'react/jsx-one-expression-per-line': [
-          'off',
-        ],
-        'react/button-has-type': [
-          'off',
-        ],
-        '@typescript-eslint/ban-types': [
-          'off',
-        ],
-        'import/no-unresolved': [
-          'off',
-        ],
-        'import/extensions': [
-          'off',
-        ],
-        'import/prefer-default-export': [
-          'off',
-        ],
-        'no-shadow': [
-          'off',
-        ],
-        '@typescript-eslint/no-shadow': [
-          'error',
-        ],
-        'no-unused-vars': [
-          'off',
-        ],
-        '@typescript-eslint/no-unused-vars': [
-          'error',
-        ],
-        'react/require-default-props': [
-          'off',
-        ],
+        radix: ['off'],
+        indent: ['off'],
+        quotes: ['error', 'single'],
+        semi: ['error', 'always'],
+        'react/function-component-definition': ['off'],
+        'react/jsx-filename-extension': ['off'],
+        'linebreak-style': ['off'],
+        'react/jsx-one-expression-per-line': ['off'],
+        'react/button-has-type': ['off'],
+        '@typescript-eslint/ban-types': ['off'],
+        'import/no-unresolved': ['off'],
+        'import/extensions': ['off'],
+        'import/prefer-default-export': ['off'],
+        'no-shadow': ['off'],
+        '@typescript-eslint/no-shadow': ['error'],
+        'no-unused-vars': ['off'],
+        '@typescript-eslint/no-unused-vars': ['error'],
+        'react/require-default-props': ['off'],
         'func-style': [
           'error',
           'declaration',
           {
             allowArrowFunctions: true,
-          }
+          },
         ],
-        'func-names': [
-          'error',
-        ],
-        'no-case-declarations': [
-          'off',
-        ],
-        'no-plusplus': [
-          'off',
-        ],
-        'no-continue': [
-          'off',
-        ],
-        'react/jsx-props-no-spreading': [
-          'off',
-        ],
+        'func-names': ['error'],
+        'no-case-declarations': ['off'],
+        'no-plusplus': ['off'],
+        'no-continue': ['off'],
+        'react/jsx-props-no-spreading': ['off'],
         'import/no-extraneous-dependencies': [
           'error',
           {
             devDependencies: true,
           },
         ],
-        'jsx-a11y/no-static-element-interactions': [
-          'off',
-        ],
-        'jsx-a11y/click-events-have-key-events': [
-          'off',
-        ],
+        'jsx-a11y/no-static-element-interactions': ['off'],
+        'jsx-a11y/click-events-have-key-events': ['off'],
         'react/jsx-no-bind': [
-          'error', {
+          'error',
+          {
             allowArrowFunctions: true,
             allowFunctions: true,
             allowBind: false,
-          }
+          },
         ],
+        'react/react-in-jsx-scope': ['off'],
       },
     },
   ],

--- a/src/Main.tsx
+++ b/src/Main.tsx
@@ -1,10 +1,9 @@
-import React from 'react';
-import styled from 'styled-components';
 import { Outlet } from 'react-router-dom';
+import styled from 'styled-components';
 
+import { DarkModeToggleOverlayButton } from '^/components/atoms/DarkModeToggleOverlayButton';
 import { Sidebar } from '^/components/organisms/Sidebar';
 import { rootNavNodes } from '^/constants/nav-node';
-import { DarkModeToggleOverlayButton } from '^/components/atoms/DarkModeToggleOverlayButton';
 
 const Root = styled.div`
   width: 100vw;

--- a/src/components/atoms/Avatar/index.test.tsx
+++ b/src/components/atoms/Avatar/index.test.tsx
@@ -1,7 +1,6 @@
-import React from 'react';
 import { cleanup, render } from '@testing-library/react';
-import { beforeEach, describe, expect, it } from 'vitest';
 import 'jest-styled-components';
+import { beforeEach, describe, expect, it } from 'vitest';
 
 import { Avatar } from '.';
 

--- a/src/components/atoms/Avatar/index.tsx
+++ b/src/components/atoms/Avatar/index.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import styled from 'styled-components';
 
 interface RootProps {

--- a/src/components/atoms/Button/index.test.tsx
+++ b/src/components/atoms/Button/index.test.tsx
@@ -1,10 +1,9 @@
-import React from 'react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import 'jest-styled-components';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { Button } from '.';
 import { ButtonType } from '^/types';
+import { Button } from '.';
 
 describe('Sample test', () => {
   beforeEach(() => {

--- a/src/components/atoms/Button/index.tsx
+++ b/src/components/atoms/Button/index.tsx
@@ -1,4 +1,4 @@
-import React, { CSSProperties, ReactNode } from 'react';
+import { CSSProperties, ReactNode } from 'react';
 import styled from 'styled-components';
 
 import { ButtonType } from '^/types';

--- a/src/components/atoms/DarkModeToggleOverlayButton/index.test.tsx
+++ b/src/components/atoms/DarkModeToggleOverlayButton/index.test.tsx
@@ -1,8 +1,7 @@
-import React from 'react';
 import { act, cleanup, render } from '@testing-library/react';
-import { beforeEach, describe, expect, it } from 'vitest';
-import { Simulate } from 'react-dom/test-utils';
 import 'jest-styled-components';
+import { Simulate } from 'react-dom/test-utils';
+import { beforeEach, describe, expect, it } from 'vitest';
 
 import { DarkModeToggleOverlayButton } from '^/components/atoms/DarkModeToggleOverlayButton';
 

--- a/src/components/atoms/DarkModeToggleOverlayButton/index.tsx
+++ b/src/components/atoms/DarkModeToggleOverlayButton/index.tsx
@@ -1,11 +1,11 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { Button } from '^/components/atoms/Button';
-import { ButtonType } from '^/types';
 import {
   COLOR_THEME_LOCAL_STORAGE_KEY,
   isDarkModeTurnedOn,
 } from '^/constants/dark-mode';
+import { ButtonType } from '^/types';
 
 export function DarkModeToggleOverlayButton() {
   const preferredTheme = window.matchMedia?.('(prefers-color-scheme: dark)')

--- a/src/components/atoms/MenuOpenCloseIcon/index.test.tsx
+++ b/src/components/atoms/MenuOpenCloseIcon/index.test.tsx
@@ -1,7 +1,6 @@
-import React from 'react';
 import { cleanup, render } from '@testing-library/react';
-import { beforeEach, describe, expect, it } from 'vitest';
 import 'jest-styled-components';
+import { beforeEach, describe, expect, it } from 'vitest';
 
 import { MenuOpenCloseIcon } from '.';
 

--- a/src/components/atoms/MenuOpenCloseIcon/index.tsx
+++ b/src/components/atoms/MenuOpenCloseIcon/index.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import styled from 'styled-components';
 
 const commonStickStyle = `

--- a/src/components/atoms/NavRouteTitle/index.test.tsx
+++ b/src/components/atoms/NavRouteTitle/index.test.tsx
@@ -1,7 +1,6 @@
-import React from 'react';
-import { beforeEach, describe, expect, it } from 'vitest';
 import { cleanup, render, screen } from '@testing-library/react';
 import { RouterProvider, createMemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it } from 'vitest';
 
 import { NavRouteTitle } from '.';
 

--- a/src/components/atoms/NavRouteTitle/index.tsx
+++ b/src/components/atoms/NavRouteTitle/index.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { useLocation } from 'react-router-dom';
 import styled from 'styled-components';
 

--- a/src/components/atoms/NavigationNode/index.test.tsx
+++ b/src/components/atoms/NavigationNode/index.test.tsx
@@ -1,7 +1,6 @@
-import React from 'react';
-import { beforeEach, describe, expect, it } from 'vitest';
 import { cleanup, render } from '@testing-library/react';
 import { RouterProvider, createMemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it } from 'vitest';
 
 import { navNodeInfoForTest } from '^/constants/nav-node';
 import { NavigationNode } from '.';

--- a/src/components/atoms/NavigationNode/index.tsx
+++ b/src/components/atoms/NavigationNode/index.tsx
@@ -1,9 +1,8 @@
-import React from 'react';
+import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 
-import { Link } from 'react-router-dom';
-import { NavNodeInfo } from '^/types';
 import { textsForNavigation } from '^/constants/texts';
+import { NavNodeInfo } from '^/types';
 
 interface RootProps {
   $url?: string;

--- a/src/components/atoms/Overlay/index.test.tsx
+++ b/src/components/atoms/Overlay/index.test.tsx
@@ -1,6 +1,5 @@
-import React from 'react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { Overlay } from '.';
 

--- a/src/components/atoms/Overlay/index.tsx
+++ b/src/components/atoms/Overlay/index.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from 'react';
+import { ReactNode } from 'react';
 import styled from 'styled-components';
 
 const Root = styled.div`

--- a/src/components/atoms/Skeleton/index.tsx
+++ b/src/components/atoms/Skeleton/index.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import styled, { CSSProp } from 'styled-components';
 
 /**

--- a/src/components/atoms/SpecialTag/index.test.tsx
+++ b/src/components/atoms/SpecialTag/index.test.tsx
@@ -1,7 +1,6 @@
-import React from 'react';
 import { cleanup, render } from '@testing-library/react';
-import { beforeEach, describe, expect, it } from 'vitest';
 import 'jest-styled-components';
+import { beforeEach, describe, expect, it } from 'vitest';
 
 import { SpecialTag } from '.';
 

--- a/src/components/atoms/SpecialTag/index.tsx
+++ b/src/components/atoms/SpecialTag/index.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from 'react';
+import { ReactNode } from 'react';
 import styled from 'styled-components';
 
 const Root = styled.span`

--- a/src/components/atoms/Thumbnail/index.test.tsx
+++ b/src/components/atoms/Thumbnail/index.test.tsx
@@ -1,6 +1,5 @@
-import React from 'react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { Thumbnail } from '.';
 

--- a/src/components/atoms/Thumbnail/index.tsx
+++ b/src/components/atoms/Thumbnail/index.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import styled from 'styled-components';
 
 const Root = styled.button`

--- a/src/components/molecules/ArticleExtra/index.test.tsx
+++ b/src/components/molecules/ArticleExtra/index.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { cleanup, render, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it } from 'vitest';
 

--- a/src/components/molecules/ArticleExtra/index.tsx
+++ b/src/components/molecules/ArticleExtra/index.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import styled from 'styled-components';
 
 import { ShmupRecord } from '^/types';

--- a/src/components/molecules/ArticleSummary/index.test.tsx
+++ b/src/components/molecules/ArticleSummary/index.test.tsx
@@ -1,8 +1,7 @@
-import React from 'react';
-import { beforeEach, describe, expect, it } from 'vitest';
 import { cleanup, render, screen } from '@testing-library/react';
+import { RouterProvider, createMemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it } from 'vitest';
 
-import { createMemoryRouter, RouterProvider } from 'react-router-dom';
 import { ShmupRecord } from '^/types';
 import { convertDateToString } from '^/utils/date-to-string';
 

--- a/src/components/molecules/ArticleSummary/index.tsx
+++ b/src/components/molecules/ArticleSummary/index.tsx
@@ -1,14 +1,14 @@
-import React, { CSSProperties, useEffect, useState } from 'react';
+import { CSSProperties, useEffect, useState } from 'react';
 import styled from 'styled-components';
 
-import { ButtonType, ShmupRecord } from '^/types';
-import { Thumbnail } from '^/components/atoms/Thumbnail';
-import { convertDateToString } from '^/utils/date-to-string';
-import { textsForArticle } from '^/constants/texts';
-import { ImageDisplayModal } from '^/components/molecules/ImageDisplayModal';
-import { Button } from '^/components/atoms/Button';
 import { ReactComponent as RawLinkSvg } from '^/assets/icons/link.svg';
 import { ReactComponent as RawTwitterSvg } from '^/assets/icons/twitter.svg';
+import { Button } from '^/components/atoms/Button';
+import { Thumbnail } from '^/components/atoms/Thumbnail';
+import { ImageDisplayModal } from '^/components/molecules/ImageDisplayModal';
+import { textsForArticle } from '^/constants/texts';
+import { ButtonType, ShmupRecord } from '^/types';
+import { convertDateToString } from '^/utils/date-to-string';
 
 const Root = styled.div`
   display: flex;

--- a/src/components/molecules/DescriptionTemplate/index.test.tsx
+++ b/src/components/molecules/DescriptionTemplate/index.test.tsx
@@ -1,6 +1,5 @@
-import React from 'react';
-import { beforeEach, describe, expect, it } from 'vitest';
 import { cleanup, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it } from 'vitest';
 
 import { DescriptionListItem } from '^/types';
 

--- a/src/components/molecules/DescriptionTemplate/index.tsx
+++ b/src/components/molecules/DescriptionTemplate/index.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import styled from 'styled-components';
 
 import { DescriptionListItem } from '^/types';

--- a/src/components/molecules/EmptyIndicator/index.test.tsx
+++ b/src/components/molecules/EmptyIndicator/index.test.tsx
@@ -1,8 +1,7 @@
-import React from 'react';
-import { beforeEach, describe, expect, it } from 'vitest';
 import { cleanup, render } from '@testing-library/react';
+import { RouterProvider, createMemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it } from 'vitest';
 
-import { createMemoryRouter, RouterProvider } from 'react-router-dom';
 import { EmptyIndicator } from '.';
 
 describe('EmptyIndicator', () => {

--- a/src/components/molecules/EmptyIndicator/index.tsx
+++ b/src/components/molecules/EmptyIndicator/index.tsx
@@ -1,6 +1,5 @@
-import React from 'react';
-import styled from 'styled-components';
 import { useNavigate } from 'react-router-dom';
+import styled from 'styled-components';
 
 import EmptyPngUrl from '^/assets/images/empty.png';
 import { Button } from '^/components/atoms/Button';

--- a/src/components/molecules/ErrorIndicator/index.test.tsx
+++ b/src/components/molecules/ErrorIndicator/index.test.tsx
@@ -1,8 +1,7 @@
-import React from 'react';
-import { beforeEach, describe, expect, it } from 'vitest';
 import { cleanup, render } from '@testing-library/react';
+import { RouterProvider, createMemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it } from 'vitest';
 
-import { createMemoryRouter, RouterProvider } from 'react-router-dom';
 import { ErrorIndicator } from '.';
 
 describe('ErrorIndicator', () => {

--- a/src/components/molecules/ErrorIndicator/index.tsx
+++ b/src/components/molecules/ErrorIndicator/index.tsx
@@ -1,6 +1,5 @@
-import React from 'react';
-import styled from 'styled-components';
 import { useNavigate } from 'react-router-dom';
+import styled from 'styled-components';
 
 import ErrorPngUrl from '^/assets/images/error.png';
 import { Button } from '^/components/atoms/Button';

--- a/src/components/molecules/ImageDisplayModal/index.test.tsx
+++ b/src/components/molecules/ImageDisplayModal/index.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   act,
   cleanup,
@@ -7,8 +5,9 @@ import {
   render,
   screen,
 } from '@testing-library/react';
-
 import { Simulate } from 'react-dom/test-utils';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
 import { ImageDisplayModal } from '.';
 
 describe('ImageDisplayModal', () => {

--- a/src/components/molecules/ImageDisplayModal/index.tsx
+++ b/src/components/molecules/ImageDisplayModal/index.tsx
@@ -1,10 +1,10 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import styled from 'styled-components';
 
-import { ImageZoomAndMoveController } from '^/components/molecules/ImageZoomAndMoveController';
-import { Overlay } from '^/components/atoms/Overlay';
 import { Button } from '^/components/atoms/Button';
 import { MenuOpenCloseIcon } from '^/components/atoms/MenuOpenCloseIcon';
+import { Overlay } from '^/components/atoms/Overlay';
+import { ImageZoomAndMoveController } from '^/components/molecules/ImageZoomAndMoveController';
 import { ButtonType } from '^/types';
 
 const CloseButtonWrapper = styled.div`

--- a/src/components/molecules/ImageZoomAndMoveController/index.test.tsx
+++ b/src/components/molecules/ImageZoomAndMoveController/index.test.tsx
@@ -1,8 +1,7 @@
-import React from 'react';
-import { beforeEach, describe, expect, it } from 'vitest';
 import { act, cleanup, render } from '@testing-library/react';
-
 import { Simulate, SyntheticEventData } from 'react-dom/test-utils';
+import { beforeEach, describe, expect, it } from 'vitest';
+
 import { ImageZoomAndMoveController } from '.';
 
 describe('ImageZoomAndMoveController', () => {

--- a/src/components/molecules/ImageZoomAndMoveController/index.tsx
+++ b/src/components/molecules/ImageZoomAndMoveController/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import styled from 'styled-components';
 
 const Root = styled.div`

--- a/src/components/molecules/NavigationForest/index.test.tsx
+++ b/src/components/molecules/NavigationForest/index.test.tsx
@@ -1,7 +1,6 @@
-import React from 'react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { RouterProvider, createMemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { navNodeInfoForTest, rootNavNodes } from '^/constants/nav-node';
 import { textsForNavigation } from '^/constants/texts';

--- a/src/components/molecules/NavigationForest/index.tsx
+++ b/src/components/molecules/NavigationForest/index.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import styled from 'styled-components';
 
 import { NavigationTree } from '^/components/molecules/NavigationTree';

--- a/src/components/molecules/NavigationTree/index.test.tsx
+++ b/src/components/molecules/NavigationTree/index.test.tsx
@@ -1,9 +1,9 @@
-import React from 'react';
-import { beforeEach, describe, expect, it } from 'vitest';
 import { cleanup, render } from '@testing-library/react';
 import { RouterProvider, createMemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it } from 'vitest';
 
 import { navNodeInfoForTest } from '^/constants/nav-node';
+
 import { NavigationTree } from '.';
 
 describe('NavigationNode', () => {

--- a/src/components/molecules/NavigationTree/index.tsx
+++ b/src/components/molecules/NavigationTree/index.tsx
@@ -1,8 +1,7 @@
-import React from 'react';
 import styled from 'styled-components';
 
-import { NavNodeInfo } from '^/types';
 import { NavigationNode } from '^/components/atoms/NavigationNode';
+import { NavNodeInfo } from '^/types';
 
 const Root = styled.div`
   padding-top: 12px;

--- a/src/components/molecules/RecordListCard/index.test.tsx
+++ b/src/components/molecules/RecordListCard/index.test.tsx
@@ -1,10 +1,10 @@
-import React from 'react';
 import { cleanup, render, screen } from '@testing-library/react';
-import { beforeEach, describe, expect, it } from 'vitest';
 import 'jest-styled-components';
+import { beforeEach, describe, expect, it } from 'vitest';
 
-import { ShmupRecordPreview } from '^/types';
 import AvatarJpgUrl from '^/assets/avatar/avatar.jpeg';
+import { ShmupRecordPreview } from '^/types';
+
 import { RecordListCard } from '.';
 
 const previewForTest: ShmupRecordPreview = {

--- a/src/components/molecules/RecordListCard/index.tsx
+++ b/src/components/molecules/RecordListCard/index.tsx
@@ -1,9 +1,8 @@
-import React from 'react';
 import styled from 'styled-components';
 
+import { ReactComponent as RawYoutubeMarkSvg } from '^/assets/icons/youtube-mark.svg';
 import { SpecialTag } from '^/components/atoms/SpecialTag';
 import { textsForArticle } from '^/constants/texts';
-import { ReactComponent as RawYoutubeMarkSvg } from '^/assets/icons/youtube-mark.svg';
 import { ShmupRecordPreview } from '^/types';
 
 const Root = styled.div`

--- a/src/components/molecules/SidebarFooter/index.test.tsx
+++ b/src/components/molecules/SidebarFooter/index.test.tsx
@@ -1,7 +1,6 @@
-import React from 'react';
-import { beforeEach, describe, expect, it } from 'vitest';
 import { cleanup, render } from '@testing-library/react';
 import 'jest-styled-components';
+import { beforeEach, describe, expect, it } from 'vitest';
 
 import { SidebarFooter } from '^/components/molecules/SidebarFooter';
 

--- a/src/components/molecules/SidebarFooter/index.tsx
+++ b/src/components/molecules/SidebarFooter/index.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import styled from 'styled-components';
 
 import { Button } from '^/components/atoms/Button';

--- a/src/components/molecules/SidebarHeader/index.test.tsx
+++ b/src/components/molecules/SidebarHeader/index.test.tsx
@@ -1,7 +1,6 @@
-import React from 'react';
 import { cleanup, fireEvent, render } from '@testing-library/react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
 import 'jest-styled-components';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { SidebarHeader } from '.';
 

--- a/src/components/molecules/SidebarHeader/index.tsx
+++ b/src/components/molecules/SidebarHeader/index.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import styled from 'styled-components';
 
 import { Button } from '^/components/atoms/Button';

--- a/src/components/molecules/TitleWithAvatar/index.test.tsx
+++ b/src/components/molecules/TitleWithAvatar/index.test.tsx
@@ -1,7 +1,6 @@
-import React from 'react';
 import { cleanup, render } from '@testing-library/react';
-import { beforeEach, describe, expect, it } from 'vitest';
 import 'jest-styled-components';
+import { beforeEach, describe, expect, it } from 'vitest';
 
 import { TitleWithAvatar } from '.';
 

--- a/src/components/molecules/TitleWithAvatar/index.tsx
+++ b/src/components/molecules/TitleWithAvatar/index.tsx
@@ -1,8 +1,7 @@
-import React from 'react';
 import styled from 'styled-components';
 
-import { Avatar } from '^/components/atoms/Avatar';
 import AvatarJpgUrl from '^/assets/avatar/avatar.jpeg';
+import { Avatar } from '^/components/atoms/Avatar';
 
 const Root = styled.div`
   height: 100%;

--- a/src/components/organisms/Article/index.test.tsx
+++ b/src/components/organisms/Article/index.test.tsx
@@ -1,8 +1,7 @@
-import React from 'react';
-import { beforeEach, describe, expect, it } from 'vitest';
 import { cleanup, render, screen } from '@testing-library/react';
+import { RouterProvider, createMemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it } from 'vitest';
 
-import { createMemoryRouter, RouterProvider } from 'react-router-dom';
 import { ShmupRecord } from '^/types';
 import { convertDateToString } from '^/utils/date-to-string';
 

--- a/src/components/organisms/Article/index.tsx
+++ b/src/components/organisms/Article/index.tsx
@@ -1,8 +1,7 @@
-import React from 'react';
 import styled from 'styled-components';
 
-import { ArticleSummary } from '^/components/molecules/ArticleSummary';
 import { ArticleExtra } from '^/components/molecules/ArticleExtra';
+import { ArticleSummary } from '^/components/molecules/ArticleSummary';
 import { ShmupRecord } from '^/types';
 
 const Root = styled.article`

--- a/src/components/organisms/RecordSelection/index.test.tsx
+++ b/src/components/organisms/RecordSelection/index.test.tsx
@@ -1,21 +1,11 @@
-import React from 'react';
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
-import { createMemoryRouter, RouterProvider } from 'react-router-dom';
-import { describe, it, beforeEach, expect } from 'vitest';
 import 'jest-styled-components';
+import { RouterProvider, createMemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it } from 'vitest';
 
 import { ShmupRecordPreview } from '^/types';
+
 import { RecordSelection } from '.';
-
-// const recordIdsForTest: string[] = ['2023-10-28', '2023-05-14', '2022-11-21'];
-
-// const recordPreviewForTest = recordIdsForTest.map(
-//   (recordId): ShmupRecordPreview => ({
-//     id: recordId,
-//     title: convertDateToString(new Date(recordId)),
-//     imageUrl: `${recordId}.jpg`,
-//   })
-// );
 
 const recordPreviewForTest: ShmupRecordPreview[] = [
   {

--- a/src/components/organisms/RecordSelection/index.tsx
+++ b/src/components/organisms/RecordSelection/index.tsx
@@ -1,10 +1,9 @@
-import React from 'react';
 import { Link } from 'react-router-dom';
 import { styled } from 'styled-components';
 
+import { EmptyIndicator } from '^/components/molecules/EmptyIndicator';
 import { RecordListCard } from '^/components/molecules/RecordListCard';
 import { ShmupRecordPreview } from '^/types';
-import { EmptyIndicator } from '^/components/molecules/EmptyIndicator';
 
 const Root = styled.div`
   display: flex;

--- a/src/components/organisms/Sidebar/index.test.tsx
+++ b/src/components/organisms/Sidebar/index.test.tsx
@@ -1,7 +1,6 @@
-import React from 'react';
-import { beforeEach, describe, expect, it } from 'vitest';
 import { cleanup, render, screen } from '@testing-library/react';
 import { RouterProvider, createMemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it } from 'vitest';
 
 import { rootNavNodes } from '^/constants/nav-node';
 

--- a/src/components/organisms/Sidebar/index.tsx
+++ b/src/components/organisms/Sidebar/index.tsx
@@ -1,11 +1,11 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import styled from 'styled-components';
 
-import { NavNodeInfo } from '^/types';
 import { NavigationForest } from '^/components/molecules/NavigationForest';
 import { SidebarFooter } from '^/components/molecules/SidebarFooter';
 import { SidebarHeader } from '^/components/molecules/SidebarHeader';
 import { TitleWithAvatar } from '^/components/molecules/TitleWithAvatar';
+import { NavNodeInfo } from '^/types';
 
 const Root = styled.div`
   height: 100%;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,14 +1,14 @@
-import React from 'react';
+import { StrictMode } from 'react';
 import ReactDOM from 'react-dom/client';
 import { RouterProvider, createBrowserRouter } from 'react-router-dom';
 
 import Main from '^/Main';
-import { LandingPage } from '^/pages/LandingPage';
-import { IntroPage } from '^/pages/IntroPage';
 import { CriteriaPage } from '^/pages/CriteriaPage';
+import { ErrorPage } from '^/pages/ErrorPage';
+import { IntroPage } from '^/pages/IntroPage';
+import { LandingPage } from '^/pages/LandingPage';
 import { RecordListPage } from '^/pages/RecordListPage';
 import { RecordPage } from '^/pages/RecordPage';
-import { ErrorPage } from '^/pages/ErrorPage';
 
 import '^/global.css';
 import { TerminologyPage } from '^/pages/TerminologyPage';
@@ -61,9 +61,9 @@ const router = createBrowserRouter([
   const root = document.querySelector('#root');
   if (root) {
     ReactDOM.createRoot(root).render(
-      <React.StrictMode>
+      <StrictMode>
         <RouterProvider router={router} />
-      </React.StrictMode>
+      </StrictMode>
     );
   }
 })();

--- a/src/pages/CriteriaPage/index.tsx
+++ b/src/pages/CriteriaPage/index.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import styled from 'styled-components';
 
 import { DescriptionTemplate } from '^/components/molecules/DescriptionTemplate';

--- a/src/pages/ErrorPage/index.tsx
+++ b/src/pages/ErrorPage/index.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { styled } from 'styled-components';
 
 import { ErrorIndicator } from '^/components/molecules/ErrorIndicator';

--- a/src/pages/IntroPage/index.tsx
+++ b/src/pages/IntroPage/index.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { DescriptionTemplate } from '^/components/molecules/DescriptionTemplate';
 import { DescriptionListItem } from '^/types';
 

--- a/src/pages/LandingPage/index.tsx
+++ b/src/pages/LandingPage/index.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import styled from 'styled-components';
 
 import GateLogoPngUrl from '^/assets/logos/gate.png';

--- a/src/pages/RecordListPage/index.tsx
+++ b/src/pages/RecordListPage/index.tsx
@@ -1,12 +1,11 @@
-import React from 'react';
 import { useParams } from 'react-router-dom';
 import styled from 'styled-components';
 
+import { Skeleton } from '^/components/atoms/Skeleton';
+import { ErrorIndicator } from '^/components/molecules/ErrorIndicator';
+import { RecordSelection } from '^/components/organisms/RecordSelection';
 import { textsForArticle } from '^/constants/texts';
 import { useShmupRecordPreviewList } from '^/hooks/useShmupRecordPreviewList';
-import { RecordSelection } from '^/components/organisms/RecordSelection';
-import { ErrorIndicator } from '^/components/molecules/ErrorIndicator';
-import { Skeleton } from '^/components/atoms/Skeleton';
 
 const Root = styled.div`
   padding-left: 15px;

--- a/src/pages/RecordPage/index.tsx
+++ b/src/pages/RecordPage/index.tsx
@@ -1,12 +1,11 @@
-import React from 'react';
-import { styled } from 'styled-components';
 import { useParams } from 'react-router-dom';
+import { styled } from 'styled-components';
 
-import { Article } from '^/components/organisms/Article';
-import { useShmupArticle } from '^/hooks/useShmupArticle';
+import { NavRouteTitle } from '^/components/atoms/NavRouteTitle';
 import { Skeleton } from '^/components/atoms/Skeleton';
 import { ErrorIndicator } from '^/components/molecules/ErrorIndicator';
-import { NavRouteTitle } from '^/components/atoms/NavRouteTitle';
+import { Article } from '^/components/organisms/Article';
+import { useShmupArticle } from '^/hooks/useShmupArticle';
 import { convertDateToString } from '^/utils/date-to-string';
 
 const Root = styled.div`

--- a/src/pages/TerminologyPage/index.tsx
+++ b/src/pages/TerminologyPage/index.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { styled } from 'styled-components';
 
 import { DescriptionTemplate } from '^/components/molecules/DescriptionTemplate';

--- a/src/playground/sample-test/index.test.tsx
+++ b/src/playground/sample-test/index.test.tsx
@@ -1,8 +1,7 @@
-import React from 'react';
-import { beforeEach, describe, expect, it } from 'vitest';
 import { cleanup, render } from '@testing-library/react';
-import styled from 'styled-components';
 import 'jest-styled-components';
+import styled from 'styled-components';
+import { beforeEach, describe, expect, it } from 'vitest';
 
 const SampleButton = styled.button`
   background-color: red;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,7 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react-jsx",
+    "jsx": "preserve",
     "baseUrl": "./src",
     "paths": {
       "^/*": ["./*"]


### PR DESCRIPTION
# Description

- Removed importing React from 'react', since [explicitly importing default React is no longer required from React 17](https://legacy.reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html).
- Rearranged all imports for all components and component tests.
