### PR TITLE
refactor: split router from entry point

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,61 +1,9 @@
 import { StrictMode } from 'react';
 import ReactDOM from 'react-dom/client';
-import { RouterProvider, createBrowserRouter } from 'react-router-dom';
-
-import Main from '^/Main';
-import { CriteriaPage } from '^/pages/CriteriaPage';
-import { ErrorPage } from '^/pages/ErrorPage';
-import { IntroPage } from '^/pages/IntroPage';
-import { LandingPage } from '^/pages/LandingPage';
-import { RecordListPage } from '^/pages/RecordListPage';
-import { RecordPage } from '^/pages/RecordPage';
+import { RouterProvider } from 'react-router-dom';
 
 import '^/global.css';
-import { TerminologyPage } from '^/pages/TerminologyPage';
-
-const router = createBrowserRouter([
-  {
-    path: '/',
-    element: <Main />,
-    children: [
-      {
-        path: '',
-        element: <LandingPage />,
-      },
-      {
-        path: 'intro',
-        element: <IntroPage />,
-      },
-      {
-        path: 'criteria',
-        element: <CriteriaPage />,
-      },
-      {
-        path: 'terminology',
-        element: <TerminologyPage />,
-      },
-      {
-        path: 'records',
-        children: [
-          {
-            path: ':typeId',
-            children: [
-              {
-                path: '',
-                element: <RecordListPage />,
-              },
-              {
-                path: ':recordDateId',
-                element: <RecordPage />,
-              },
-            ],
-          },
-        ],
-      },
-    ],
-    errorElement: <ErrorPage />,
-  },
-]);
+import { router } from '^/route';
 
 (() => {
   const root = document.querySelector('#root');

--- a/src/route.tsx
+++ b/src/route.tsx
@@ -1,0 +1,54 @@
+import { createBrowserRouter } from 'react-router-dom';
+
+import Main from '^/Main';
+import { CriteriaPage } from '^/pages/CriteriaPage';
+import { ErrorPage } from '^/pages/ErrorPage';
+import { IntroPage } from '^/pages/IntroPage';
+import { LandingPage } from '^/pages/LandingPage';
+import { RecordListPage } from '^/pages/RecordListPage';
+import { RecordPage } from '^/pages/RecordPage';
+import { TerminologyPage } from '^/pages/TerminologyPage';
+
+export const router = createBrowserRouter([
+  {
+    path: '/',
+    element: <Main />,
+    children: [
+      {
+        path: '',
+        element: <LandingPage />,
+      },
+      {
+        path: 'intro',
+        element: <IntroPage />,
+      },
+      {
+        path: 'criteria',
+        element: <CriteriaPage />,
+      },
+      {
+        path: 'terminology',
+        element: <TerminologyPage />,
+      },
+      {
+        path: 'records',
+        children: [
+          {
+            path: ':typeId',
+            children: [
+              {
+                path: '',
+                element: <RecordListPage />,
+              },
+              {
+                path: ':recordDateId',
+                element: <RecordPage />,
+              },
+            ],
+          },
+        ],
+      },
+    ],
+    errorElement: <ErrorPage />,
+  },
+]);


### PR DESCRIPTION
# Description

- Moved `router` out from `index.tsx` to improve code visibility and ensure the role of each module.
