### PR TITLE
fix: have navigation sidebar covering entire screen to prevent unnecessarily scrolling body on mobile

### DIFF
--- a/src/components/organisms/NavigationSidebar/index.tsx
+++ b/src/components/organisms/NavigationSidebar/index.tsx
@@ -23,6 +23,10 @@ const Container = styled.div`
   grid-template-rows: auto 1fr auto;
 
   background: var(--primary-color);
+
+  @media (max-width: 1000px) {
+    width: 100%;
+  }
 `;
 
 interface Props {


### PR DESCRIPTION
# Description

- Changed NavigationSidebar to cover entire screen on mobile.
  - It will prevent unnecessarily scrolling body while opening NavigationSidebar on mobile devices.
