### PR TITLE
refactor: rename dark mode button

### DIFF
--- a/src/components/atoms/DarkModeToggleButton/__snapshots__/index.test.tsx.snap
+++ b/src/components/atoms/DarkModeToggleButton/__snapshots__/index.test.tsx.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`DarkModeToggleOverlayButton > should have a snapshot match 1`] = `
+exports[`DarkModeToggleButton > should have a snapshot match 1`] = `
 .c0 {
   all: unset;
   box-sizing: border-box;

--- a/src/components/atoms/DarkModeToggleButton/index.test.tsx
+++ b/src/components/atoms/DarkModeToggleButton/index.test.tsx
@@ -3,20 +3,20 @@ import 'jest-styled-components';
 import { Simulate } from 'react-dom/test-utils';
 import { beforeEach, describe, expect, it } from 'vitest';
 
-import { DarkModeToggleOverlayButton } from '^/components/atoms/DarkModeToggleOverlayButton';
+import { DarkModeToggleButton } from '^/components/atoms/DarkModeToggleButton';
 
-describe('DarkModeToggleOverlayButton', () => {
+describe('DarkModeToggleButton', () => {
   beforeEach(() => {
     cleanup();
   });
 
   it('should have a snapshot match', () => {
-    const { container } = render(<DarkModeToggleOverlayButton />);
+    const { container } = render(<DarkModeToggleButton />);
     expect(container.firstChild).toMatchSnapshot();
   });
 
   it('should have a clickable button', async () => {
-    const { container } = render(<DarkModeToggleOverlayButton />);
+    const { container } = render(<DarkModeToggleButton />);
 
     act(() => {
       if (

--- a/src/components/atoms/DarkModeToggleButton/index.tsx
+++ b/src/components/atoms/DarkModeToggleButton/index.tsx
@@ -22,7 +22,7 @@ const MoonSvgrepoSvg = styled(RawMoonSvgrepoSvg)`
   fill: var(--white-color);
 `;
 
-export function DarkModeToggleOverlayButton() {
+export function DarkModeToggleButton() {
   const preferredTheme = window.matchMedia?.('(prefers-color-scheme: dark)')
     .matches
     ? 'dark'

--- a/src/components/organisms/Header/index.tsx
+++ b/src/components/organisms/Header/index.tsx
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 
 import { Button } from '^/components/atoms/Button';
-import { DarkModeToggleOverlayButton } from '^/components/atoms/DarkModeToggleOverlayButton';
+import { DarkModeToggleButton } from '^/components/atoms/DarkModeToggleButton';
 import { MenuOpenCloseIcon } from '^/components/atoms/MenuOpenCloseIcon';
 import { ButtonType } from '^/types';
 
@@ -50,7 +50,7 @@ export function Header({ onClickOpenOrCloseNavigationButton }: Props) {
         <MenuOpenCloseIcon isOpen={false} />
       </Button>
       <Title>YSOShmupRecords</Title>
-      <DarkModeToggleOverlayButton />
+      <DarkModeToggleButton />
     </Root>
   );
 }


### PR DESCRIPTION
# Description

- Renamed `DarkModeToggleOverlayButton` to `DarkModeToggleButton`, since the button is not on overlay anymore.
