### PR TITLE
fix: make going back button work on enter article by shared link

### DIFF
--- a/src/components/atoms/GoBackButton/index.test.tsx
+++ b/src/components/atoms/GoBackButton/index.test.tsx
@@ -1,7 +1,7 @@
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import 'jest-styled-components';
-import { beforeEach, describe, expect, it } from 'vitest';
 import { RouterProvider, createMemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it } from 'vitest';
 
 import { GoBackButton } from '.';
 
@@ -14,7 +14,7 @@ describe('DarkModeToggleButton', () => {
     const routes = [
       {
         path: '/',
-        element: <GoBackButton />,
+        element: <GoBackButton typeId="yasuo" />,
       },
     ];
 
@@ -27,22 +27,21 @@ describe('DarkModeToggleButton', () => {
     expect(container.firstChild).toMatchSnapshot();
   });
 
-  it('should go back on click', async () => {
+  it('should go to record list on click', async () => {
     const routes = [
       {
-        path: '/koishi/hoshino',
+        path: '/records/koishi-hoshino/1234-56-78',
         element: (
           <div>
-            <GoBackButton />
+            <GoBackButton typeId="koishi-hoshino" />
             <div>애기코이시 애기호시노</div>
           </div>
         ),
       },
       {
-        path: '/yasuo/science',
+        path: '/records/koishi-hoshino',
         element: (
           <div>
-            <GoBackButton />
             <div>야스오는 과학이다</div>
           </div>
         ),
@@ -50,8 +49,8 @@ describe('DarkModeToggleButton', () => {
     ];
 
     const router = createMemoryRouter(routes, {
-      initialEntries: ['/yasuo/science', '/koishi/hoshino'],
-      initialIndex: 1,
+      initialEntries: ['/records/koishi-hoshino/1234-56-78'],
+      initialIndex: 0,
     });
 
     render(<RouterProvider router={router} />);

--- a/src/components/atoms/GoBackButton/index.tsx
+++ b/src/components/atoms/GoBackButton/index.tsx
@@ -3,7 +3,11 @@ import { useNavigate } from 'react-router-dom';
 import { Button } from '^/components/atoms/Button';
 import { ButtonType } from '^/types';
 
-export function GoBackButton() {
+interface Props {
+  typeId: string;
+}
+
+export function GoBackButton({ typeId }: Props) {
   const navigate = useNavigate();
 
   return (
@@ -14,7 +18,7 @@ export function GoBackButton() {
       }}
       isDisabled={false}
       onClick={() => {
-        navigate(-1);
+        navigate(`/records/${typeId}`);
       }}
     >
       목록으로 돌아가기

--- a/src/pages/RecordPage/index.tsx
+++ b/src/pages/RecordPage/index.tsx
@@ -1,13 +1,13 @@
 import { useParams } from 'react-router-dom';
 import { styled } from 'styled-components';
 
+import { GoBackButton } from '^/components/atoms/GoBackButton';
 import { NavRouteTitle } from '^/components/atoms/NavRouteTitle';
 import { Skeleton } from '^/components/atoms/Skeleton';
 import { ErrorIndicator } from '^/components/molecules/ErrorIndicator';
 import { Article } from '^/components/organisms/Article';
 import { useShmupArticle } from '^/hooks/useShmupArticle';
 import { convertDateToString } from '^/utils/date-to-string';
-import { GoBackButton } from '^/components/atoms/GoBackButton';
 
 const Root = styled.div`
   width: 100%;
@@ -82,7 +82,7 @@ export function RecordPage() {
 
   return (
     <Root>
-      <GoBackButton />
+      <GoBackButton typeId={typeId} />
       <TitleArea>
         <Title>{convertDateToString(new Date(recordDateId))}</Title>
         <NavRouteTitle />


### PR DESCRIPTION
# Description

- Fix `GoBackButton` not working when entered a shmup record article firstly. (for example, by shared link)
