### PR TITLE
refactor: replace api call parameters into object

### DIFF
--- a/src/apis/get-shmup-record-article.ts
+++ b/src/apis/get-shmup-record-article.ts
@@ -1,21 +1,30 @@
+import axios from 'axios';
+
 import { GetShmupRecordArticleResponse, ShmupRecord } from '^/types';
 import { getAPIURL } from '^/utils/get-api-url';
 
 import { apiClient } from './api';
 
-export async function getShmupRecordArticle(
-  typeId: string,
-  recordId: string,
-  onLoad: (newIsLoading: boolean) => void,
-  onError: (newIsError: boolean) => void,
-  onComplete: (newShmupRecordArticle: ShmupRecord) => void
-) {
-  onLoad(true);
-  onError(false);
+interface Params {
+  typeId: string;
+  recordDateId: string;
+  onStart: () => void;
+  onError: (error: Error) => void;
+  onComplete: (newShmupRecordArticle: ShmupRecord) => void;
+}
+
+export async function getShmupRecordArticle({
+  typeId,
+  recordDateId,
+  onStart,
+  onError,
+  onComplete,
+}: Params) {
+  onStart();
 
   try {
     const response = await apiClient.get<GetShmupRecordArticleResponse>(
-      getAPIURL('records', typeId, recordId)
+      getAPIURL('records', typeId, recordDateId)
     );
     onComplete({
       ...response.data.data,
@@ -27,8 +36,10 @@ export async function getShmupRecordArticle(
      */
     // eslint-disable-next-line no-console
     console.error(error);
-    onError(true);
+    if (axios.isAxiosError(error)) {
+      onError(error);
+    } else {
+      onError(new Error('Something else went wrong.'));
+    }
   }
-
-  onLoad(false);
 }

--- a/src/apis/get-shmup-record-preview-list.ts
+++ b/src/apis/get-shmup-record-preview-list.ts
@@ -1,17 +1,25 @@
+import axios from 'axios';
+
 import { GetShmupRecordPreviewListResponse, ShmupRecordPreview } from '^/types';
 import { convertDateToString } from '^/utils/date-to-string';
 import { getAPIURL } from '^/utils/get-api-url';
 
 import { apiClient } from './api';
 
-export async function getShmupRecordPreviewList(
-  typeId: string,
-  onLoad: (newIsLoading: boolean) => void,
-  onError: (newIsError: boolean) => void,
-  onComplete: (newShmupRecordPreviews: ShmupRecordPreview[]) => void
-) {
-  onLoad(true);
-  onError(false);
+interface Params {
+  typeId: string;
+  onStart: () => void;
+  onError: (error: Error) => void;
+  onComplete: (newShmupRecordPreviews: ShmupRecordPreview[]) => void;
+}
+
+export async function getShmupRecordPreviewList({
+  typeId,
+  onStart,
+  onError,
+  onComplete,
+}: Params) {
+  onStart();
 
   try {
     const response = await apiClient.get<GetShmupRecordPreviewListResponse>(
@@ -34,8 +42,10 @@ export async function getShmupRecordPreviewList(
      */
     // eslint-disable-next-line no-console
     console.error(error);
-    onError(false);
+    if (axios.isAxiosError(error)) {
+      onError(error);
+    } else {
+      onError(new Error('Something else went wrong.'));
+    }
   }
-
-  onLoad(false);
 }

--- a/src/hooks/useShmupArticle.ts
+++ b/src/hooks/useShmupArticle.ts
@@ -9,13 +9,22 @@ export function useShmupArticle(typeId: string, recordDateId: string) {
   const [isError, setIsError] = useState<boolean>(false);
 
   useEffect(() => {
-    getShmupRecordArticle(
+    getShmupRecordArticle({
       typeId,
       recordDateId,
-      setIsLoading,
-      setIsError,
-      setRecordArticle
-    );
+      onStart: () => {
+        setIsLoading(true);
+        setIsError(false);
+      },
+      onError: () => {
+        setIsError(true);
+        setIsLoading(false);
+      },
+      onComplete: (newShmupRecordArticle) => {
+        setRecordArticle(newShmupRecordArticle);
+        setIsLoading(false);
+      },
+    });
   }, [typeId, recordDateId]);
 
   return {

--- a/src/hooks/useShmupRecordPreviewList.ts
+++ b/src/hooks/useShmupRecordPreviewList.ts
@@ -11,12 +11,21 @@ export function useShmupRecordPreviewList(typeId: string) {
   const [isError, setIsError] = useState<boolean>(false);
 
   useEffect(() => {
-    getShmupRecordPreviewList(
+    getShmupRecordPreviewList({
       typeId,
-      setIsLoading,
-      setIsError,
-      setRecordPreviews
-    );
+      onStart: () => {
+        setIsLoading(true);
+        setIsError(false);
+      },
+      onError: () => {
+        setIsError(true);
+        setIsLoading(false);
+      },
+      onComplete: (newShmupRecordPreviews) => {
+        setRecordPreviews(newShmupRecordPreviews);
+        setIsLoading(false);
+      },
+    });
   }, [typeId]);
 
   return {


### PR DESCRIPTION
# Description

- Replaced API call functions' parameters into an object.
  - `getShmupRecordArticle` and `getShmupRecordPreviewList`
