### PR TITLE
improvement: make seeing list of all type shmup records available

### DIFF
--- a/src/components/molecules/RecordListCard/__snapshots__/index.test.tsx.snap
+++ b/src/components/molecules/RecordListCard/__snapshots__/index.test.tsx.snap
@@ -79,7 +79,7 @@ exports[`RecordListCard > should have a snapshot match for its appearance 1`] = 
     class="c1"
   >
     <img
-      alt="kuman514"
+      alt="kumankoishi shmup record 2024-01-01"
       class="c2"
       src="/src/assets/avatar/avatar.jpeg"
     />
@@ -94,6 +94,11 @@ exports[`RecordListCard > should have a snapshot match for its appearance 1`] = 
       class="c5"
     >
       kuman514
+    </span>
+    <span
+      class="c5"
+    >
+      kumankoishi shmup record 2024-01-01
     </span>
     <span
       class="c6"
@@ -207,7 +212,7 @@ exports[`RecordListCard > should have a snapshot match showing youtube mark and 
     class="c1"
   >
     <img
-      alt="kuman514"
+      alt="kumankoishi shmup record 2024-01-01"
       class="c2"
       src="/src/assets/avatar/avatar.jpeg"
     />
@@ -222,6 +227,11 @@ exports[`RecordListCard > should have a snapshot match showing youtube mark and 
       class="c5"
     >
       kuman514
+    </span>
+    <span
+      class="c5"
+    >
+      kumankoishi shmup record 2024-01-01
     </span>
     <span
       class="c6"

--- a/src/components/molecules/RecordListCard/index.test.tsx
+++ b/src/components/molecules/RecordListCard/index.test.tsx
@@ -8,7 +8,7 @@ import { ShmupRecordPreview } from '^/types';
 import { RecordListCard } from '.';
 
 const previewForTest: ShmupRecordPreview = {
-  title: 'kuman514',
+  title: 'kumankoishi shmup record 2024-01-01',
   recordId: 'test-test',
   when: new Date('2024-01-01'),
   typeId: 'test',

--- a/src/components/molecules/RecordListCard/index.tsx
+++ b/src/components/molecules/RecordListCard/index.tsx
@@ -130,6 +130,9 @@ export function RecordListCard({ recordPreview }: Props) {
         <ImageContainerOverlay />
       </ImageContainer>
       <Summary>
+        <Title>
+          {textsForArticle[recordPreview.typeId] ?? recordPreview.typeId}
+        </Title>
         <Title>{recordPreview.title}</Title>
         <StageAndScore>{`${recordPreview.stage} / ${recordPreview.score}점`}</StageAndScore>
         {renderSpecialTags}

--- a/src/components/organisms/RecordSelection/__snapshots__/index.test.tsx.snap
+++ b/src/components/organisms/RecordSelection/__snapshots__/index.test.tsx.snap
@@ -219,6 +219,11 @@ exports[`RecordSelection > should match snapshot with non-empty recordIds 1`] = 
           <span
             class="c9"
           >
+            도돈파치 (1997): C-Shot
+          </span>
+          <span
+            class="c9"
+          >
             2023년 10월 28일
           </span>
           <span
@@ -254,6 +259,11 @@ exports[`RecordSelection > should match snapshot with non-empty recordIds 1`] = 
           <span
             class="c9"
           >
+            도돈파치 (1997): C-Shot
+          </span>
+          <span
+            class="c9"
+          >
             2023년 5월 14일
           </span>
           <span
@@ -286,6 +296,11 @@ exports[`RecordSelection > should match snapshot with non-empty recordIds 1`] = 
         <div
           class="c8"
         >
+          <span
+            class="c9"
+          >
+            도돈파치 (1997): C-Shot
+          </span>
           <span
             class="c9"
           >

--- a/src/constants/nav-node.ts
+++ b/src/constants/nav-node.ts
@@ -41,6 +41,7 @@ export const rootNavNodes: NavNodeInfo[] = [
   },
   {
     id: 'records',
+    linkTo: '/records',
     childNavNodes: [
       {
         id: 'dodonpachi',

--- a/src/hooks/useShmupRecordPreviewList.ts
+++ b/src/hooks/useShmupRecordPreviewList.ts
@@ -3,7 +3,7 @@ import { useEffect, useState } from 'react';
 import { getShmupRecordPreviewList } from '^/apis/get-shmup-record-preview-list';
 import { ShmupRecordPreview } from '^/types';
 
-export function useShmupRecordPreviewList(typeId: string) {
+export function useShmupRecordPreviewList(typeId?: string) {
   const [recordPreviews, setRecordPreviews] = useState<ShmupRecordPreview[]>(
     []
   );

--- a/src/pages/RecordListPage/index.tsx
+++ b/src/pages/RecordListPage/index.tsx
@@ -46,10 +46,6 @@ function RecordListCardSkeleton() {
 export function RecordListPage() {
   const { typeId } = useParams();
 
-  if (!typeId) {
-    return null;
-  }
-
   const { recordPreviews, isLoading, isError } =
     useShmupRecordPreviewList(typeId);
 
@@ -72,9 +68,13 @@ export function RecordListPage() {
     return <RecordSelection recordPreviews={recordPreviews} />;
   })();
 
+  const renderRecordTypeTitle = typeId
+    ? (textsForArticle[typeId] ?? typeId)
+    : '모든 슈팅게임';
+
   return (
     <Root>
-      <Title>{textsForArticle[typeId] ?? typeId} 기록 목록</Title>
+      <Title>{renderRecordTypeTitle} 기록 목록</Title>
       {renderRecordSelectionArea}
     </Root>
   );

--- a/src/route.tsx
+++ b/src/route.tsx
@@ -34,6 +34,10 @@ export const router = createBrowserRouter([
         path: 'records',
         children: [
           {
+            path: '',
+            element: <RecordListPage />,
+          },
+          {
             path: ':typeId',
             children: [
               {


### PR DESCRIPTION
# Description

- Made `useShmupRecordPreviewList` browse all type shmup records when a shmup record's `typeId` is absent as a parameter.
- Added record type name into `RecordListCard`.
