### PR TITLE
improvement: reduce record nav-nodes to show primary types & fill the space with other contents

### DIFF
--- a/src/constants/nav-node.ts
+++ b/src/constants/nav-node.ts
@@ -44,83 +44,20 @@ export const rootNavNodes: NavNodeInfo[] = [
     linkTo: '/records',
     childNavNodes: [
       {
-        id: 'dodonpachi',
-        childNavNodes: [
-          {
-            id: 'dodonpachi-ashot',
-            linkTo: '/records/dodonpachi-ashot',
-          },
-          {
-            id: 'dodonpachi-alaser',
-            linkTo: '/records/dodonpachi-alaser',
-          },
-          {
-            id: 'dodonpachi-bshot',
-            linkTo: '/records/dodonpachi-bshot',
-          },
-          {
-            id: 'dodonpachi-blaser',
-            linkTo: '/records/dodonpachi-blaser',
-          },
-          {
-            id: 'dodonpachi-cshot',
-            linkTo: '/records/dodonpachi-cshot',
-          },
-          {
-            id: 'dodonpachi-claser',
-            linkTo: '/records/dodonpachi-claser',
-          },
-        ],
+        id: 'dodonpachi-cshot',
+        linkTo: '/records/dodonpachi-cshot',
       },
       {
         id: 'galagaarrangement',
         linkTo: '/records/galagaarrangement',
       },
       {
-        id: 'dariusgaiden',
-        childNavNodes: [
-          {
-            id: 'dariusgaiden-zprime',
-            linkTo: '/records/dariusgaiden-zprime',
-          },
-          {
-            id: 'dariusgaiden-v',
-            linkTo: '/records/dariusgaiden-v',
-          },
-          {
-            id: 'dariusgaiden-w',
-            linkTo: '/records/dariusgaiden-w',
-          },
-          {
-            id: 'dariusgaiden-x',
-            linkTo: '/records/dariusgaiden-x',
-          },
-          {
-            id: 'dariusgaiden-y',
-            linkTo: '/records/dariusgaiden-y',
-          },
-          {
-            id: 'dariusgaiden-z',
-            linkTo: '/records/dariusgaiden-z',
-          },
-          {
-            id: 'dariusgaiden-vprime',
-            linkTo: '/records/dariusgaiden-vprime',
-          },
-        ],
+        id: 'ketsui-b',
+        linkTo: '/records/ketsui-b',
       },
       {
-        id: 'ketsui',
-        childNavNodes: [
-          {
-            id: 'ketsui-a',
-            linkTo: '/records/ketsui-a',
-          },
-          {
-            id: 'ketsui-b',
-            linkTo: '/records/ketsui-b',
-          },
-        ],
+        id: 'inthehunt',
+        linkTo: '/records/inthehunt',
       },
     ],
   },

--- a/src/constants/texts.ts
+++ b/src/constants/texts.ts
@@ -15,27 +15,10 @@ export const textsForNavigation: Record<string, string> = {
   criteria: '등록 기준',
   records: '기록',
   terminology: '용어',
-  dodonpachi: '도돈파치 (1997)',
-  'dodonpachi-ashot': 'A-Shot',
-  'dodonpachi-alaser': 'A-Laser',
-  'dodonpachi-bshot': 'B-Shot',
-  'dodonpachi-blaser': 'B-Laser',
-  'dodonpachi-cshot': 'C-Shot',
-  'dodonpachi-claser': 'C-Laser',
+  'dodonpachi-cshot': '도돈파치 (1997): C-Shot',
   galagaarrangement: '갤러그 어레인지먼트',
-  dariusgaiden: '다라이어스 외전',
-  // prettier-ignore
-  'dariusgaiden-zprime': 'Z\'존',
-  'dariusgaiden-v': 'V존',
-  'dariusgaiden-w': 'W존',
-  'dariusgaiden-x': 'X존',
-  'dariusgaiden-y': 'Y존',
-  'dariusgaiden-z': 'Z존',
-  // prettier-ignore
-  'dariusgaiden-vprime': 'V\'존',
-  ketsui: '케츠이',
-  'ketsui-a': 'A타입',
-  'ketsui-b': 'B타입',
+  'ketsui-b': '케츠이: B타입',
+  inthehunt: '인더헌트 (해저대전쟁 해외판)',
 };
 
 export const textsForArticle: Record<string, string> = {
@@ -75,6 +58,7 @@ export const textsForArticle: Record<string, string> = {
   ketsui: '케츠이',
   'ketsui-a': '케츠이: A타입',
   'ketsui-b': '케츠이: B타입',
+  inthehunt: '인더헌트 (해저대전쟁 해외판)',
   /**
    * Method names
    */


### PR DESCRIPTION
# Description

- Reduced shmup record nav-nodes - shows only shmups that I play frequently, and the rest will be shown on all-type record list.
  - This is for filling the empty space with other contents like shmup reviews or galleries.
- Added In The Hunt to shmup record nav-nodes.
