### PR TITLE
fix: correct wrong navigation on click all-type record list card

### DIFF
--- a/src/components/organisms/RecordSelection/__snapshots__/index.test.tsx.snap
+++ b/src/components/organisms/RecordSelection/__snapshots__/index.test.tsx.snap
@@ -196,7 +196,7 @@ exports[`RecordSelection > should match snapshot with non-empty recordIds 1`] = 
   >
     <a
       class="c3"
-      href="/2023-10-28"
+      href="/records/dodonpachi-cshot/2023-10-28"
     >
       <div
         class="c4"
@@ -236,7 +236,7 @@ exports[`RecordSelection > should match snapshot with non-empty recordIds 1`] = 
     </a>
     <a
       class="c3"
-      href="/2023-05-14"
+      href="/records/dodonpachi-cshot/2023-05-14"
     >
       <div
         class="c4"
@@ -276,7 +276,7 @@ exports[`RecordSelection > should match snapshot with non-empty recordIds 1`] = 
     </a>
     <a
       class="c3"
-      href="/2022-11-21"
+      href="/records/dodonpachi-cshot/2022-11-21"
     >
       <div
         class="c4"

--- a/src/components/organisms/RecordSelection/index.test.tsx
+++ b/src/components/organisms/RecordSelection/index.test.tsx
@@ -92,13 +92,13 @@ describe('RecordSelection', () => {
         element: <RecordSelection recordPreviews={recordPreviewForTest} />,
       },
       {
-        path: '/2023-05-14',
+        path: '/records/dodonpachi-cshot/2023-05-14',
         element: <div>Correct!</div>,
       },
     ];
 
     const router = createMemoryRouter(routes, {
-      initialEntries: ['/', '/2023-05-14'],
+      initialEntries: ['/', '/records/dodonpachi-cshot/2023-05-14'],
       initialIndex: 0,
     });
 

--- a/src/components/organisms/RecordSelection/index.tsx
+++ b/src/components/organisms/RecordSelection/index.tsx
@@ -48,7 +48,7 @@ export function RecordSelection({ recordPreviews }: Props) {
       {recordPreviews.map((recordPreview) => (
         <RecordSelectionLink
           key={recordPreview.recordId}
-          to={recordPreview.recordId.split('--')[1]}
+          to={`/records/${recordPreview.recordId.split('--').join('/')}`}
         >
           <RecordListCard recordPreview={recordPreview} />
         </RecordSelectionLink>


### PR DESCRIPTION
# Description

- Corrected wrong navigation when clicking a `RecordListCard` in all-type record list page `/records`.
