### PR TITLE
refactor: remove on-handlers from get-api calls

### DIFF
--- a/src/apis/get-shmup-record-article.ts
+++ b/src/apis/get-shmup-record-article.ts
@@ -1,6 +1,6 @@
 import axios from 'axios';
 
-import { GetShmupRecordArticleResponse, ShmupRecord } from '^/types';
+import { GetResponse, GetResult, ShmupRecord } from '^/types';
 import { getAPIURL } from '^/utils/get-api-url';
 
 import { apiClient } from './api';
@@ -8,38 +8,36 @@ import { apiClient } from './api';
 interface Params {
   typeId: string;
   recordDateId: string;
-  onStart: () => void;
-  onError: (error: Error) => void;
-  onComplete: (newShmupRecordArticle: ShmupRecord) => void;
 }
 
 export async function getShmupRecordArticle({
   typeId,
   recordDateId,
-  onStart,
-  onError,
-  onComplete,
-}: Params) {
-  onStart();
-
+}: Params): Promise<GetResult<ShmupRecord>> {
   try {
-    const response = await apiClient.get<GetShmupRecordArticleResponse>(
+    const response = await apiClient.get<GetResponse<ShmupRecord>>(
       getAPIURL('records', typeId, recordDateId)
     );
-    onComplete({
-      ...response.data.data,
-      when: new Date(response.data.data.when),
-    });
+
+    return {
+      status: 'successful',
+      data: {
+        ...response.data.data,
+        when: new Date(response.data.data.when),
+      },
+    };
   } catch (error) {
     /**
      * 에러 출력이 필요하므로 no-console을 이 줄에 한해 해제함
      */
     // eslint-disable-next-line no-console
     console.error(error);
-    if (axios.isAxiosError(error)) {
-      onError(error);
-    } else {
-      onError(new Error('Something else went wrong.'));
-    }
+
+    return {
+      status: 'failed',
+      errorMessage: axios.isAxiosError(error)
+        ? error
+        : new Error('Something else went wrong.'),
+    };
   }
 }

--- a/src/apis/get-shmup-record-preview-list.ts
+++ b/src/apis/get-shmup-record-preview-list.ts
@@ -11,7 +11,7 @@ import { getAPIURL } from '^/utils/get-api-url';
 
 import { apiClient } from './api';
 
-export async function getShmupRecordPreviewList(
+export async function getShmupRecordList(
   typeId?: string
 ): Promise<GetResult<ShmupRecordPreview[]>> {
   try {

--- a/src/apis/get-shmup-record-preview-list.ts
+++ b/src/apis/get-shmup-record-preview-list.ts
@@ -1,30 +1,24 @@
 import axios from 'axios';
 
-import { GetShmupRecordPreviewListResponse, ShmupRecordPreview } from '^/types';
+import {
+  GetResponse,
+  GetResult,
+  ShmupRecord,
+  ShmupRecordPreview,
+} from '^/types';
 import { convertDateToString } from '^/utils/date-to-string';
 import { getAPIURL } from '^/utils/get-api-url';
 
 import { apiClient } from './api';
 
-interface Params {
-  typeId?: string;
-  onStart: () => void;
-  onError: (error: Error) => void;
-  onComplete: (newShmupRecordPreviews: ShmupRecordPreview[]) => void;
-}
-
-export async function getShmupRecordPreviewList({
-  typeId,
-  onStart,
-  onError,
-  onComplete,
-}: Params) {
-  onStart();
-
+export async function getShmupRecordPreviewList(
+  typeId?: string
+): Promise<GetResult<ShmupRecordPreview[]>> {
   try {
-    const response = await apiClient.get<GetShmupRecordPreviewListResponse>(
-      typeId ? getAPIURL('records', typeId) : getAPIURL('records')
+    const response = await apiClient.get<GetResponse<ShmupRecord[]>>(
+      getAPIURL('records', typeId ?? '')
     );
+
     const newRecordPreviews = response.data.data
       .map((record): ShmupRecordPreview => {
         const dateFromString = new Date(record.when);
@@ -44,17 +38,23 @@ export async function getShmupRecordPreviewList({
 
         return a.typeId.localeCompare(b.typeId);
       });
-    onComplete(newRecordPreviews);
+
+    return {
+      status: 'successful',
+      data: newRecordPreviews,
+    };
   } catch (error) {
     /**
      * 에러 출력이 필요하므로 no-console을 이 줄에 한해 해제함
      */
     // eslint-disable-next-line no-console
     console.error(error);
-    if (axios.isAxiosError(error)) {
-      onError(error);
-    } else {
-      onError(new Error('Something else went wrong.'));
-    }
+
+    return {
+      status: 'failed',
+      errorMessage: axios.isAxiosError(error)
+        ? error
+        : new Error('Something else went wrong.'),
+    };
   }
 }

--- a/src/hooks/useShmupArticle.ts
+++ b/src/hooks/useShmupArticle.ts
@@ -9,22 +9,28 @@ export function useShmupArticle(typeId: string, recordDateId: string) {
   const [isError, setIsError] = useState<boolean>(false);
 
   useEffect(() => {
-    getShmupRecordArticle({
-      typeId,
-      recordDateId,
-      onStart: () => {
-        setIsLoading(true);
-        setIsError(false);
-      },
-      onError: () => {
-        setIsError(true);
-        setIsLoading(false);
-      },
-      onComplete: (newShmupRecordArticle) => {
-        setRecordArticle(newShmupRecordArticle);
-        setIsLoading(false);
-      },
-    });
+    (async () => {
+      setIsLoading(true);
+      setIsError(false);
+
+      const result = await getShmupRecordArticle({
+        typeId,
+        recordDateId,
+      });
+
+      switch (result.status) {
+        case 'successful':
+          setRecordArticle(result.data);
+          break;
+        case 'failed':
+          setIsError(true);
+          break;
+        default:
+          break;
+      }
+
+      setIsLoading(false);
+    })();
   }, [typeId, recordDateId]);
 
   return {

--- a/src/hooks/useShmupRecordList.ts
+++ b/src/hooks/useShmupRecordList.ts
@@ -1,9 +1,9 @@
 import { useEffect, useState } from 'react';
 
-import { getShmupRecordPreviewList } from '^/apis/get-shmup-record-preview-list';
+import { getShmupRecordList } from '^/apis/get-shmup-record-preview-list';
 import { ShmupRecordPreview } from '^/types';
 
-export function useShmupRecordPreviewList(typeId?: string) {
+export function useShmupRecordList(typeId?: string) {
   const [recordPreviews, setRecordPreviews] = useState<ShmupRecordPreview[]>(
     []
   );
@@ -15,7 +15,7 @@ export function useShmupRecordPreviewList(typeId?: string) {
       setIsLoading(true);
       setIsError(false);
 
-      const result = await getShmupRecordPreviewList(typeId);
+      const result = await getShmupRecordList(typeId);
 
       switch (result.status) {
         case 'successful':

--- a/src/hooks/useShmupRecordPreviewList.ts
+++ b/src/hooks/useShmupRecordPreviewList.ts
@@ -11,21 +11,25 @@ export function useShmupRecordPreviewList(typeId?: string) {
   const [isError, setIsError] = useState<boolean>(false);
 
   useEffect(() => {
-    getShmupRecordPreviewList({
-      typeId,
-      onStart: () => {
-        setIsLoading(true);
-        setIsError(false);
-      },
-      onError: () => {
-        setIsError(true);
-        setIsLoading(false);
-      },
-      onComplete: (newShmupRecordPreviews) => {
-        setRecordPreviews(newShmupRecordPreviews);
-        setIsLoading(false);
-      },
-    });
+    (async () => {
+      setIsLoading(true);
+      setIsError(false);
+
+      const result = await getShmupRecordPreviewList(typeId);
+
+      switch (result.status) {
+        case 'successful':
+          setRecordPreviews(result.data);
+          break;
+        case 'failed':
+          setIsError(true);
+          break;
+        default:
+          break;
+      }
+
+      setIsLoading(false);
+    })();
   }, [typeId]);
 
   return {

--- a/src/pages/RecordListPage/index.tsx
+++ b/src/pages/RecordListPage/index.tsx
@@ -5,7 +5,7 @@ import { Skeleton } from '^/components/atoms/Skeleton';
 import { ErrorIndicator } from '^/components/molecules/ErrorIndicator';
 import { RecordSelection } from '^/components/organisms/RecordSelection';
 import { textsForArticle } from '^/constants/texts';
-import { useShmupRecordPreviewList } from '^/hooks/useShmupRecordPreviewList';
+import { useShmupRecordList } from '^/hooks/useShmupRecordList';
 
 const Root = styled.div`
   padding-left: 15px;
@@ -46,8 +46,7 @@ function RecordListCardSkeleton() {
 export function RecordListPage() {
   const { typeId } = useParams();
 
-  const { recordPreviews, isLoading, isError } =
-    useShmupRecordPreviewList(typeId);
+  const { recordPreviews, isLoading, isError } = useShmupRecordList(typeId);
 
   const renderRecordSelectionArea = (() => {
     if (isLoading) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -54,3 +54,21 @@ export interface GetShmupRecordArticleResponse {
   statusCode: number;
   data: ShmupRecord;
 }
+
+export interface GetResponse<T> {
+  attempts: number;
+  statusCode: number;
+  data: T;
+}
+
+export interface SuccessfulGetResult<T> {
+  status: 'successful';
+  data: T;
+}
+
+export interface FailedGetResult {
+  status: 'failed';
+  errorMessage: Error;
+}
+
+export type GetResult<T> = SuccessfulGetResult<T> | FailedGetResult;


### PR DESCRIPTION
# Description

- Removed on-handlers from API calls. (`getShmupRecordArticle` and `getShmupRecordList` (formerly `getShmupRecordPreviewList`))