### PR TITLE
fix: correct wrong text color when the app is in light mode

### DIFF
--- a/src/components/molecules/Tabbar/index.tsx
+++ b/src/components/molecules/Tabbar/index.tsx
@@ -39,6 +39,7 @@ export function Tabbar({ tabNames, currentTabIndex, onClick }: Props) {
                 : 'none',
             wordBreak: 'keep-all',
             flexGrow: 1,
+            color: 'inherit',
           }}
         >
           {tabName}


### PR DESCRIPTION
# Description

- Corrected wrong text color in `Tabbar` in light mode.
  - Texts in `Tabbar` will now be black in light mode & white in dark mode.
