### PR TITLE
fix: expand contact-button & move it more right-bottom for better appearance

### DIFF
--- a/src/components/atoms/ContactButton/__snapshots__/index.test.tsx.snap
+++ b/src/components/atoms/ContactButton/__snapshots__/index.test.tsx.snap
@@ -34,7 +34,7 @@ exports[`ContactButton > should have a snapshot match 1`] = `
 
 <button
   class="c0"
-  style="position: fixed; bottom: 32px; right: 32px; z-index: 21; width: 48px; height: 48px; padding: 0px; border-radius: 50%; display: flex; justify-content: center; align-items: center;"
+  style="position: fixed; bottom: 24px; right: 24px; z-index: 21; width: 64px; height: 64px; padding: 0px; border-radius: 50%; display: flex; justify-content: center; align-items: center;"
 >
   <svg
     class="c1"

--- a/src/components/atoms/ContactButton/index.tsx
+++ b/src/components/atoms/ContactButton/index.tsx
@@ -20,11 +20,11 @@ export function ContactButton({ onClick }: Props) {
       type={ButtonType.ROUND_SOLID}
       customStyle={{
         position: 'fixed',
-        bottom: '32px',
-        right: '32px',
+        bottom: '24px',
+        right: '24px',
         zIndex: 21,
-        width: '48px',
-        height: '48px',
+        width: '64px',
+        height: '64px',
         padding: 0,
         borderRadius: '50%',
         display: 'flex',


### PR DESCRIPTION
# Description

- Expanded `ContactButton` from `48px * 48px` to `64px * 64px`.
- Moved `ContactButton` 8px closer to the bottom and 8px closer to the right.
