### PR TITLE
improvement: add instruction for how to open image modal in shmup article page

### DIFF
--- a/src/components/molecules/ArticleSummary/index.test.tsx
+++ b/src/components/molecules/ArticleSummary/index.test.tsx
@@ -85,4 +85,21 @@ describe('ArticleSummary', () => {
     expect(screen.getByText(/no miss/i)).not.toBeNull();
     expect(screen.getByText(/노미스 ALL/i)).not.toBeNull();
   });
+
+  it('should serve instruction for how to turn on image modal', () => {
+    const routes = [
+      {
+        path: '/',
+        element: <ArticleSummary record={testDataWithSpecialTags} />,
+      },
+    ];
+
+    const router = createMemoryRouter(routes, {
+      initialEntries: ['/'],
+      initialIndex: 0,
+    });
+
+    render(<RouterProvider router={router} />);
+    expect(screen.getByText(/\[ 클릭하여 모든 이미지 보기 \]/i)).not.toBeNull();
+  });
 });

--- a/src/components/molecules/ArticleSummary/index.tsx
+++ b/src/components/molecules/ArticleSummary/index.tsx
@@ -18,6 +18,18 @@ const Root = styled.div`
   gap: 16px;
 `;
 
+const ThumbnailWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 4px;
+`;
+
+const ThumbnailInstruction = styled.span`
+  font-size: 12px;
+`;
+
 const SummaryDescription = styled.div`
   display: flex;
   flex-direction: column;
@@ -193,15 +205,20 @@ export function ArticleSummary({ record }: Props) {
   return (
     <>
       <Root>
-        <Thumbnail
-          imageSrc={record.thumbnailUrl}
-          altText={`${record.typeId} ${convertDateToString(record.when)} ${
-            record.stage
-          }스테이지 ${record.score}점`}
-          onClick={() => {
-            setIsImageModalShow(true);
-          }}
-        />
+        <ThumbnailWrapper>
+          <Thumbnail
+            imageSrc={record.thumbnailUrl}
+            altText={`${record.typeId} ${convertDateToString(record.when)} ${
+              record.stage
+            }스테이지 ${record.score}점`}
+            onClick={() => {
+              setIsImageModalShow(true);
+            }}
+          />
+          <ThumbnailInstruction>
+            [ 클릭하여 모든 이미지 보기 ]
+          </ThumbnailInstruction>
+        </ThumbnailWrapper>
         <SummaryDescription>
           {renderList}
           <ShareButtonList>


### PR DESCRIPTION
# Description

- Added instruction about how to open `ImageDisplayModal` in a shmup record article page.
  - This PR will prevent quit seeing without clicking thumbnail and then seeing all the original images.