### PR TITLE
chore: get back to read-only api base url until aws free tier expires

### DIFF
--- a/src/apis/api.ts
+++ b/src/apis/api.ts
@@ -1,5 +1,5 @@
 import axios from 'axios';
 
 export const apiClient = axios.create({
-  baseURL: import.meta.env.VITE_API_URL,
+  baseURL: 'https://koishi-hoshino-contents.vercel.app/yso-shmup-records',
 });

--- a/src/apis/get-shmup-record-article.ts
+++ b/src/apis/get-shmup-record-article.ts
@@ -1,6 +1,6 @@
 import axios from 'axios';
 
-import { GetResponse, GetResult, ShmupRecord } from '^/types';
+import { GetResult, ShmupRecord } from '^/types';
 import { getAPIURL } from '^/utils/get-api-url';
 
 import { apiClient } from './api';
@@ -15,15 +15,15 @@ export async function getShmupRecordArticle({
   recordDateId,
 }: Params): Promise<GetResult<ShmupRecord>> {
   try {
-    const response = await apiClient.get<GetResponse<ShmupRecord>>(
+    const response = await apiClient.get<ShmupRecord>(
       getAPIURL('records', typeId, recordDateId)
     );
 
     return {
       status: 'successful',
       data: {
-        ...response.data.data,
-        when: new Date(response.data.data.when),
+        ...response.data,
+        when: new Date(response.data.when),
       },
     };
   } catch (error) {

--- a/src/apis/get-shmup-record-preview-list.ts
+++ b/src/apis/get-shmup-record-preview-list.ts
@@ -1,11 +1,6 @@
 import axios from 'axios';
 
-import {
-  GetResponse,
-  GetResult,
-  ShmupRecord,
-  ShmupRecordPreview,
-} from '^/types';
+import { GetResult, ShmupRecord, ShmupRecordPreview } from '^/types';
 import { convertDateToString } from '^/utils/date-to-string';
 import { getAPIURL } from '^/utils/get-api-url';
 
@@ -15,11 +10,11 @@ export async function getShmupRecordList(
   typeId?: string
 ): Promise<GetResult<ShmupRecordPreview[]>> {
   try {
-    const response = await apiClient.get<GetResponse<ShmupRecord[]>>(
-      getAPIURL('records', typeId ?? '')
+    const response = await apiClient.get<ShmupRecord[]>(
+      typeId ? getAPIURL('records', `${typeId}.json`) : 'records.json'
     );
 
-    const newRecordPreviews = response.data.data
+    const newRecordPreviews = response.data
       .map((record): ShmupRecordPreview => {
         const dateFromString = new Date(record.when);
         return {


### PR DESCRIPTION
# Description

- Migrate back to ReadOnlyAPIEndpoints since the AWS Free Tier expires in Dec 31 2024.
