### PR TITLE
chore: release 2024-12-21

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,8 @@ YSO(kuman514)가 주력으로 플레이하는 슈팅게임의 기록을 등록�
   - `인삿말` YSOShmupRecords가 만들어진 목적과 페이지에서 주요 성과를 추가하였습니다.
 - `2024년 10월 7일`
   - 기록 아티클과 기록 목록을 로딩할 때 표시할 스켈레톤 컴포넌트를 변경하였습니다.
+- `2024년 12월 21일`
+  - AWS 프리 티어 만료로 인해 YSOShmupRecords 종료. (YSOArcadeRecords)[https://github.com/kuman514/YSOArcadeRecords]로 이관 중.
 
 ## Feedbacks
 - ~~트위터에 기록된 게임들이 많은 것 같은데 그것도 이 프로젝트에 다루는게 어떨까?~~ (반영 완료)

--- a/src/apis/api.ts
+++ b/src/apis/api.ts
@@ -1,5 +1,5 @@
 import axios from 'axios';
 
 export const apiClient = axios.create({
-  baseURL: import.meta.env.VITE_API_URL,
+  baseURL: 'https://koishi-hoshino-contents.vercel.app/yso-shmup-records',
 });

--- a/src/apis/get-shmup-record-article.ts
+++ b/src/apis/get-shmup-record-article.ts
@@ -1,6 +1,6 @@
 import axios from 'axios';
 
-import { GetResponse, GetResult, ShmupRecord } from '^/types';
+import { GetResult, ShmupRecord } from '^/types';
 import { getAPIURL } from '^/utils/get-api-url';
 
 import { apiClient } from './api';
@@ -15,15 +15,15 @@ export async function getShmupRecordArticle({
   recordDateId,
 }: Params): Promise<GetResult<ShmupRecord>> {
   try {
-    const response = await apiClient.get<GetResponse<ShmupRecord>>(
+    const response = await apiClient.get<ShmupRecord>(
       getAPIURL('records', typeId, recordDateId)
     );
 
     return {
       status: 'successful',
       data: {
-        ...response.data.data,
-        when: new Date(response.data.data.when),
+        ...response.data,
+        when: new Date(response.data.when),
       },
     };
   } catch (error) {

--- a/src/apis/get-shmup-record-preview-list.ts
+++ b/src/apis/get-shmup-record-preview-list.ts
@@ -1,11 +1,6 @@
 import axios from 'axios';
 
-import {
-  GetResponse,
-  GetResult,
-  ShmupRecord,
-  ShmupRecordPreview,
-} from '^/types';
+import { GetResult, ShmupRecord, ShmupRecordPreview } from '^/types';
 import { convertDateToString } from '^/utils/date-to-string';
 import { getAPIURL } from '^/utils/get-api-url';
 
@@ -15,11 +10,11 @@ export async function getShmupRecordList(
   typeId?: string
 ): Promise<GetResult<ShmupRecordPreview[]>> {
   try {
-    const response = await apiClient.get<GetResponse<ShmupRecord[]>>(
-      getAPIURL('records', typeId ?? '')
+    const response = await apiClient.get<ShmupRecord[]>(
+      typeId ? getAPIURL('records', `${typeId}.json`) : 'records.json'
     );
 
-    const newRecordPreviews = response.data.data
+    const newRecordPreviews = response.data
       .map((record): ShmupRecordPreview => {
         const dateFromString = new Date(record.when);
         return {


### PR DESCRIPTION
# Description

- Migrate back to ReadOnlyAPIEndpoints since the AWS Free Tier expires in Dec 31 2024.
- Shutdown YSOShmupRecords, and moved to YSOArcadeRecords.
